### PR TITLE
Reverse geocoding: Add entire location object if latlng is not in expected format

### DIFF
--- a/src/esri-leaflet-geocoder.js
+++ b/src/esri-leaflet-geocoder.js
@@ -33,7 +33,13 @@
     },
     reverse: function(latlng, opts, callback, context){
       var params = opts || {};
-      params.location = [latlng.lng, latlng.lat].join(',');
+      if(latlng) {
+        if(latlng.lat && latlng.lng) {
+          params.location = [latlng.lng, latlng.lat].join(',');
+        } else {
+          params.location = latlng;
+        }
+      }
       this.get('reverseGeocode', params, function(error, response){
         if(error) {
           callback.call(context, error);


### PR DESCRIPTION
I had a problem where I needed to specify a spatial reference when reverse geocoding.
The service takes location in either commaseparated format, or as a JSON point like this:

`{ 
"x": 10,
"y": 20,
"spatialReference": {
    "wkid": 3857
}
}`

I modified the `reverse` function to use the entire `latlng` object as `location` if the `.lat` or `.lng` properties are missing. This way I can explicitly set the spatial reference.
