### PR TITLE
Add support for empty geocoding Task constructors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ The Esri Leaflet Geocoder is a small series of API helpers and UI controls to in
 
 ![Travis CI](https://travis-ci.org/Esri/esri-leaflet-geocoder.svg)
 
-**Currently Esri Leaflet Geocoder is in development and should be thoguht of as a beta or preview**
+**Currently Esri Leaflet Geocoder is in development and should be thought of as a beta or preview**
 
-Esri Leaflet Geocoder relies on the minimal Esri Leaflet Core which handles abstraction for requests and authentication when neccessary. You can fine out more about the Esri Leaflet Core on the [Esri Leaflet downloads page](http://esri.github.com/esri-leaflet/downloads).
+Esri Leaflet Geocoder relies on the minimal Esri Leaflet Core which handles abstraction for requests and authentication when neccessary. You can find out more about the Esri Leaflet Core on the [Esri Leaflet downloads page](http://esri.github.com/esri-leaflet/downloads).
 
 ## Example
 
@@ -50,7 +50,7 @@ Take a look at the [live demo](http://esri.github.com/esri-leaflet/examples/geoc
       var tiles = L.tileLayer("http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png").addTo(map);
 
       // create the geocoding control and add it to the map
-      var searchControl = new L.esri.Controls.Geosearch().addTo(map);
+      var searchControl = new L.esri.Geocoding.Controls.Geosearch().addTo(map);
 
       // create an empty layer group to store the results and add it to the map
       var results = new L.LayerGroup().addTo(map);
@@ -91,6 +91,7 @@ Option | Type | Default | Description
 `useArcgisWorldGeocoder` | `Boolean` | `true` | Use the ArcGIS Online World Geocoder by default in the array of providers.
 `providers` | `Array` | See Description | An array of `EsriLeafletGeocoding.Controls.Geosearch.Providers` objects. These additional providers will also be searched for possible results and added to the suggestion list.
 `placeholder` | `String` | `'Search for places or addresses'` | Placeholder text for the search input.
+`title` | `String` | `Location Search` | Title text for the search input. Shows as tool tip on hover.
 
 ### Methods
 
@@ -123,7 +124,7 @@ For reference here is the internal structure of the geocoder...
 
 ### Providers
 
-The `Geosearch` control can also search for results from a varity of sources includeing Feature Layers and Map Services. This is done with plain text matching and is not "real" geocoding. But it allows you to mix custom results into search box.
+The `Geosearch` control can also search for results from a varity of sources including Feature Layers and Map Services. This is done with plain text matching and is not "real" geocoding. But it allows you to mix custom results into search box.
 
 ```js
 var gisDay = new L.esri.Geocoding.Controls.Geosearch.Providers.FeatureLayer('https://services.arcgis.com/uCXeTVveQzP4IIcx/arcgis/rest/services/GIS_Day_Final/FeatureServer/0', {
@@ -208,7 +209,7 @@ L.esri.Services.FeatureLayer fires all L.esri.Services.service events.
 
 Constructor | Description
 --- | ---
-`new L.esri.Geocoding.Tasks.Geocode(url, options)`<br>`L.esri.Geocoding.Tasks.geocode(url, options)` | Creates a new Geocode task. `L.esri.Geocoding.WorldGeocodingService` can be used as a reference to the ArcGIS Online World Geocoder.
+`new L.esri.Geocoding.Tasks.Geocode(url, options)`<br>`L.esri.Geocoding.Tasks.geocode(url, options)` | Creates a new Geocode task. The ArcGIS Online World Geocoder will be leveraged if nothing is provided in the Task constructor.
 
 ### Options
 
@@ -234,13 +235,13 @@ Method | Returns | Description
 ### Examples
 
 ```js
-L.esri.Geocoding.Tasks.geocode(L.esri.Geocoding.WorldGeocodingService).text('380 New York St, Redlands, California, 92373').run(function(err, results, response){
+L.esri.Geocoding.Tasks.geocode().text('380 New York St, Redlands, California, 92373').run(function(err, results, response){
   console.log(results);
 });
 ```
 
 ```js
-L.esri.Geocoding.Tasks.geocode(L.esri.Geocoding.WorldGeocodingService).address('380 New York St').city('Redlands').region('California').postal(92373).run(function(err, results, response){
+L.esri.Geocoding.Tasks.geocode().address('380 New York St').city('Redlands').region('California').postal(92373).run(function(err, results, response){
   console.log(results);
 });
 ```
@@ -251,7 +252,7 @@ var southWest = L.latLng(37.712, -108.227),
     northEast = L.latLng(41.774, -102.125),
     bounds = L.latLngBounds(southWest, northEast); // Colorado
 
-L.esri.Geocoding.Tasks.geocode(L.esri.Geocoding.WorldGeocodingService).text("Denver").within(bounds).run(function(err, response){
+L.esri.Geocoding.Tasks.geocode().text("Denver").within(bounds).run(function(err, response){
   console.log(response);
 });
 ```
@@ -260,7 +261,7 @@ L.esri.Geocoding.Tasks.geocode(L.esri.Geocoding.WorldGeocodingService).text("Den
 //Using .nearby()
 var denver = L.latLng(37.712, -108.227);
 
-L.esri.Geocoding.Tasks.geocode(L.esri.Geocoding.WorldGeocodingService).text("Highlands Ranch").nearby(denver, 20000).run(function(err, response){
+L.esri.Geocoding.Tasks.geocode().text("Highlands Ranch").nearby(denver, 20000).run(function(err, response){
   console.log(response);
 });
 ```
@@ -292,7 +293,7 @@ In the above examples the `results` object will look like this.
 
 Constructor | Description
 --- | ---
-`new L.esri.Geocoding.Tasks.Suggest(url, options)`<br>`L.esri.Geocoding.Tasks.suggest(url, options)` | Creates a new Suggest task. `L.esri.Geocoding.WorldGeocodingService` can be used as a reference to the ArcGIS Online World Geocoder.
+`new L.esri.Geocoding.Tasks.Suggest(url, options)`<br>`L.esri.Geocoding.Tasks.suggest(url, options)` | Creates a new Suggest task. The ArcGIS Online World Geocoder will be leveraged if nothing is provided in the Task constructor.
 
 ### Options
 
@@ -322,7 +323,7 @@ L.esri.Geocoding.Tasks.suggest().text('trea').nearby([45,-121], 5000).run(functi
 
 Constructor | Description
 --- | ---
-`new L.esri.Geocoding.Tasks.ReverseGeocode(url, options)`<br>`L.esri.Geocoding.Tasks.reverseGeocode(url, options)` | Creates a new ReverseGeocode task. `L.esri.Geocoding.WorldGeocodingService` can be used as a reference to the ArcGIS Online World Geocoder.
+`new L.esri.Geocoding.Tasks.ReverseGeocode(url, options)`<br>`L.esri.Geocoding.Tasks.reverseGeocode(url, options)` | Creates a new ReverseGeocode task. The ArcGIS Online World Geocoder will be leveraged if nothing is provided in the Task constructor.
 
 ### Options
 

--- a/spec/Tasks/ReverseGeocodeSpec.js
+++ b/spec/Tasks/ReverseGeocodeSpec.js
@@ -54,8 +54,8 @@ describe('L.esri.Tasks.ReverseGeocode', function () {
     xhr.restore();
   });
 
-  it('should make a reverse geocode request to ArcGIS Online', function(done){
-    var request = L.esri.Geocoding.Tasks.reverseGeocode(L.esri.Geocoding.WorldGeocodingService).latlng([48.8583,  2.2945]).run(function(error, result, response){
+  it('should make a reverse geocode request to ArcGIS Online with an empty constructor', function(done){
+    var request = L.esri.Geocoding.Tasks.reverseGeocode().latlng([48.8583,  2.2945]).run(function(error, result, response){
       expect(result.latlng.lat).to.equal(48.857489996304814);
       expect(result.latlng.lng).to.equal(2.2946500041892821);
       expect(result.address.Address).to.equal('6 Avenue Gustave Eiffel');
@@ -92,8 +92,8 @@ describe('L.esri.Tasks.ReverseGeocode', function () {
     request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, sampleResponse);
   });
 
-  it('should make a reverse geocode request with a language param', function(done){
-    var request = L.esri.Geocoding.Tasks.reverseGeocode(L.esri.Geocoding.WorldGeocodingService).latlng([48.8583,  2.2945]).language('fr').distance(200).run(function(error, result, response){
+  it('should make a reverse geocode request with a language param, empty constructor', function(done){
+    var request = L.esri.Geocoding.Tasks.reverseGeocode().latlng([48.8583,  2.2945]).language('fr').distance(200).run(function(error, result, response){
       expect(result.address.Address).to.equal('Rue de la Sablonnière 16');
       done();
     });

--- a/spec/Tasks/SuggestSpec.js
+++ b/spec/Tasks/SuggestSpec.js
@@ -52,8 +52,8 @@ describe('L.esri.Tasks.Suggest', function () {
     request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, sampleResponse);
   });
 
-  it('should make a suggest request with a nearby filter', function(done){
-    var request = L.esri.Geocoding.Tasks.suggest(L.esri.Geocoding.WorldGeocodingService).text('trea').nearby([45,-121], 5000).run(function(error, response){
+  it('should make a suggest request with a nearby filter, empty constructor', function(done){
+    var request = L.esri.Geocoding.Tasks.suggest().text('trea').nearby([45,-121], 5000).run(function(error, response){
       expect(response.suggestions.length).to.equal(5);
       done();
     });

--- a/src/Tasks/Geocode.js
+++ b/src/Tasks/Geocode.js
@@ -25,6 +25,21 @@ EsriLeafletGeocoding.Tasks.Geocode = Esri.Tasks.Task.extend({
     'maxLocations': 'maxLocations'
   },
 
+  initialize: function(url, options){
+    //need to handle both direct instantiations and those coming from controls
+    if ( url && url.hasOwnProperty('url') ){
+      url = url.url;
+      options = url.options;
+    } else {
+      url = (typeof url === 'string') ? url : EsriLeafletGeocoding.WorldGeocodingService;
+      options = (typeof url === 'object') ? url : (options || {});
+      this.url = Esri.Util.cleanUrl(url);
+      L.Util.setOptions(this, options);
+    }
+    //don't replace parent initialize
+    L.esri.Tasks.Task.prototype.initialize.call(this, url, options);
+  },
+
   within: function(bounds){
     bounds = L.latLngBounds(bounds);
     this.params.bbox = Esri.Util.boundsToExtent(bounds);

--- a/src/Tasks/ReverseGeocode.js
+++ b/src/Tasks/ReverseGeocode.js
@@ -9,6 +9,22 @@ EsriLeafletGeocoding.Tasks.ReverseGeocode = Esri.Tasks.Task.extend({
     'language': 'language'
   },
 
+  initialize: function(url, options){
+    //need to handle both direct instantiations and those coming from controls
+    if ( url && url.hasOwnProperty('url') ){
+      url = url.url;
+      options = url.options;
+    } else {
+      url = (typeof url === 'string') ? url : EsriLeafletGeocoding.WorldGeocodingService;
+      options = (typeof url === 'object') ? url : (options || {});
+      this.url = Esri.Util.cleanUrl(url);
+      L.Util.setOptions(this, options);
+    }
+    //don't replace parent initialize
+    L.esri.Tasks.Task.prototype.initialize.call(this, url, options);
+
+  },
+
   latlng: function (latlng) {
     latlng = L.latLng(latlng);
     this.params.location = latlng.lng + ',' + latlng.lat;

--- a/src/Tasks/Suggest.js
+++ b/src/Tasks/Suggest.js
@@ -8,6 +8,21 @@ EsriLeafletGeocoding.Tasks.Suggest = Esri.Tasks.Task.extend({
     category: 'category'
   },
 
+  initialize: function(url, options){
+    //need to handle both direct instantiations and those coming from controls
+    if ( url && url.hasOwnProperty('url') ){
+      url = url.url;
+      options = url.options;
+    } else {
+      url = (typeof url === 'string') ? url : EsriLeafletGeocoding.WorldGeocodingService;
+      options = (typeof url === 'object') ? url : (options || {});
+      this.url = Esri.Util.cleanUrl(url);
+      L.Util.setOptions(this, options);
+    }
+    //don't replace parent initialize
+    L.esri.Tasks.Task.prototype.initialize.call(this, url, options);
+  },
+
   within: function(bounds){
     bounds = L.latLngBounds(bounds);
     bounds = bounds.pad(0.5);


### PR DESCRIPTION
as mentioned in my #49 comment.  it seems helpful to just assume people want to use the World Geocoding Service so that developers can just instantiate a Task object with an empty constructor.

ie:
`L.esri.Geocoding.Tasks.geocode()`

made code change and added a relevant test.  
also updated a reused variable in GeoSearch.js to make jshint happy.

let me know if this is unwanted or if there is a more desirable approach.  if its all good, i can update the doc as well.