### PR TITLE
add 'searchExtent' to suggest requests dynamically

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "leaflet": "^0.7.0",
-    "esri-leaflet": "1.0.0-rc.5"
+    "esri-leaflet": "^1.0.0-rc.5"
   }
 }

--- a/src/Tasks/Suggest.js
+++ b/src/Tasks/Suggest.js
@@ -22,6 +22,7 @@ EsriLeafletGeocoding.Tasks.Suggest = Esri.Tasks.Task.extend({
     var ne = bounds.getNorthWest();
     this.params.location = center.lng + ',' + center.lat;
     this.params.distance = Math.min(Math.max(center.distanceTo(ne), 2000), 50000);
+    this.params.searchExtent = L.esri.Util.boundsToExtent(bounds);
     return this;
   },
 


### PR DESCRIPTION
currently, when `useMapBounds` is true, for suggest requests, we append `location` and `distance` parameters dynamically but fail to set `searchExtent`.  this has the undesired effect of ranking results based on their proximity to map center, but failing to omit results outside the relevant bounding box.

STR:
1. load [this](http://esri.github.io/esri-leaflet/examples/geocoding-control.html) sample and zoom in on downtown portland (past level 12, which sets useMapBounds automatically).
2. search for 'voodoo' and notice that the Portland match is returned first, but results in other locations are included in the result as well.

proposed fix is included.  additional, tangentially related discussion can be found in #38 
