### PR TITLE
added support for custom 10.3 geocoding services that support 'suggest'

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ L.esri.Geocoding.Controls.geosearch({
 
 Option | Type | Default | Description
 --- | --- | --- | ---
-`url` | `String` | Depends | The URL for the service that will be used to search. Varys by provider, usally a service or layer URL or a geocoding service URL.
+`url` | `String` | Depends | The URL for the service that will be used to search. Varys by provider, usually a service or layer URL or a geocoding service URL.
 `searchFields` | `Array[Strings]` | None | An array of fields to search for text. Not valid for the `ArcGISOnline` and `GeocodeService` providers.
 `layer` | `Integer` | `0` | Only valid for `MapService` providers, the layer to find text matches on.
 `label` | `String` | Provider Type | Text that will be used to group suggestions under.
@@ -230,7 +230,7 @@ Method | Returns | Description
 `region(text <String>)` | Specify the region to be geocoded. Typically a state or province
 `postal(text <String>)` | Specify the postal code to be geocoded.
 `country(text <String>)` | Specify the country to be geocoded.
-`category(category <String>)` | The category to search for suggestions. By default no category. A list of categories can be found here https://developers.arcgis.com/rest/geocode/api-reference/geocoding-category-filtering.htm#ESRI_SECTION1_502B3FE2028145D7B189C25B1A00E17B
+`category(category <String>)` | The category to search for suggestions. By default no category. A list of categories can be found [here](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-category-filtering.htm#ESRI_SECTION1_502B3FE2028145D7B189C25B1A00E17B)
 `within(bounds <L.LatLngBounds>)` | A bounding box to search for suggestions in.
 `nearby(latlng <L.LatLng>, distance <Integer>)` | Searches for suggestions only inside an area around the LatLng. `distance` is in meters.
 `run(callback <Function>, context <Object>)` | `XMLHttpRequest` | Executes this request chain and accepts the response callback.
@@ -307,7 +307,7 @@ You can pass any options you can pass to L.esri.Tasks.Task. `url` will be the Ar
 Method | Returns | Description
 --- | --- | ---
 `text(text <String>)` | `this` | The text to recive suggestions for.
-`category(category <String>)` | The category to search for suggestions. By default no categogy. A list of categories can be found here https://developers.arcgis.com/rest/geocode/api-reference/geocoding-category-filtering.htm#ESRI_SECTION1_502B3FE2028145D7B189C25B1A00E17B
+`category(category <String>)` | The category to search for suggestions. By default no categogy. A list of categories can be found [here](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-category-filtering.htm#ESRI_SECTION1_502B3FE2028145D7B189C25B1A00E17B)
 `within(bounds <L.LatLngBounds>)` | A bounding box to search for suggestions in.
 `nearby(latlng <L.LatLng>, distance <Integer>)` | Searches for suggestions only inside an area around the LatLng. `distance` is in meters.
 `run(callback <Function>, context<Object>)` | `XMLHttpRequest` | Executes this request chain and accepts the response callback.

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Option | Type | Default | Description
 `label` | `String` | Provider Type | Text that will be used to group suggestions under.
 `maxResults` | `Integer` | 5 | Maximum number of results to show for this provider.
 `bufferRadius`, | `Integer` | If a service or layer contains points, buffer points by this radius to create bounds. Not valid for the `ArcGISOnline` and `GeocodeService` providers
-`formatSuggestion`| `Function` | See Description | Formating function for the suggestion text. Receives a feature and returns a string.
+`formatSuggestion`| `Function` | See Description | Formating function for the suggestion text from `FeatureLayer` provider. Receives a feature and returns a string.
 
 #### Results Event
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ L.esri.Geocoding.Controls.geosearch({
 * `L.esri.Geocoding.Controls.Geosearch.Providers.ArcGISOnline` - Included by default unless the `useArcgisWorldGeocoder` option is set to false.
 * `L.esri.Geocoding.Controls.Geosearch.Providers.FeatureLayer` - Gets results by querying the Feature Layer for text matches.
 * `L.esri.Geocoding.Controls.Geosearch.Providers.MapService` - Uses the find and query methods on the Map Service to get text matches.
-* `L.esri.Geocoding.Controls.Geosearch.Providers.GeocodeService` - Use a ArcGIS Server Geocode Service. This option does not support suggestions.
+* `L.esri.Geocoding.Controls.Geosearch.Providers.GeocodeService` - Use a ArcGIS Server Geocode Service.
 
 #### Provider Options
 
@@ -156,7 +156,7 @@ Option | Type | Default | Description
 `url` | `String` | Depends | The URL for the service that will be used to search. Varys by provider, usually a service or layer URL or a geocoding service URL.
 `searchFields` | `Array[Strings]` | None | An array of fields to search for text. Not valid for the `ArcGISOnline` and `GeocodeService` providers.
 `layer` | `Integer` | `0` | Only valid for `MapService` providers, the layer to find text matches on.
-`label` | `String` | Provider Type | Text that will be used to group suggestions under.
+`label` | `String` | Provider Type | Text that will be used to group suggestions under when more than one provider is being used.
 `maxResults` | `Integer` | 5 | Maximum number of results to show for this provider.
 `bufferRadius`, | `Integer` | If a service or layer contains points, buffer points by this radius to create bounds. Not valid for the `ArcGISOnline` and `GeocodeService` providers
 `formatSuggestion`| `Function` | See Description | Formating function for the suggestion text from `FeatureLayer` provider. Receives a feature and returns a string.
@@ -216,7 +216,7 @@ Constructor | Description
 
 ### Options
 
-You can pass any options you can pass to L.esri.Tasks.Task. `url` will be the ArcGIS World Geocoder by default but a custom geocoding service can also be used.
+You can pass any options you can pass to L.esri.Tasks.Task. `url` will be the [ArcGIS World Geocoder](https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm) by default but a custom geocoding service can also be used.
 
 ### Methods
 
@@ -300,7 +300,7 @@ Constructor | Description
 
 ### Options
 
-You can pass any options you can pass to L.esri.Tasks.Task. `url` will be the ArcGIS World Geocoder by default but a custom geocoding service can also be used.
+You can pass any options you can pass to L.esri.Tasks.Task. `url` will be the [ArcGIS World Geocoder](https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm) by default but a custom geocoding service can also be used.
 
 ### Methods
 
@@ -326,7 +326,7 @@ L.esri.Geocoding.Tasks.suggest().text('trea').nearby([45,-121], 5000).run(functi
 
 Constructor | Description
 --- | ---
-`new L.esri.Geocoding.Tasks.ReverseGeocode(options)`<br>`L.esri.Geocoding.Tasks.reverseGeocode(options)` | Creates a new ReverseGeocode task. `L.esri.Geocoding.WorldGeocodingService` can be used as a reference to the ArcGIS Online World Geocoder.
+`new L.esri.Geocoding.Tasks.ReverseGeocode(options)`<br>`L.esri.Geocoding.Tasks.reverseGeocode(options)` | Creates a new ReverseGeocode task. `L.esri.Geocoding.WorldGeocodingService` can be used as a reference to the [ArcGIS World Geocoder](https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm).
 
 ### Options
 
@@ -390,7 +390,7 @@ In order the use the ArcGIS Online Geocoding Service you should signup for an [A
 This information is from the [ArcGIS for Developers Terms of Use FAQ](https://developers.arcgis.com/en/terms/faq/) and the [ArcGIS Online World Geocoder documentation](http://resources.arcgis.com/en/help/arcgis-rest-api/#/Single_input_field_geocoding/02r300000015000000/)
 
 ## Licensing
-Copyright 2013 Esri
+Copyright 2015 Esri
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/debug/sample.html
+++ b/debug/sample.html
@@ -44,7 +44,8 @@
 
       L.esri.Geocoding.Controls.geosearch({
         providers: [
-          new L.esri.Geocoding.Controls.Geosearch.Providers.FeatureLayer('https://services.arcgis.com/uCXeTVveQzP4IIcx/arcgis/rest/services/GIS_Day/FeatureServer/0', {
+          new L.esri.Geocoding.Controls.Geosearch.Providers.FeatureLayer({
+            url: 'https://services.arcgis.com/uCXeTVveQzP4IIcx/arcgis/rest/services/GIS_Day/FeatureServer/0',
             searchFields: ['EventName', 'Organizati'],
             label: 'GIS Day Events',
             formatSuggestion: function(feature){

--- a/src/Controls/Geosearch.js
+++ b/src/Controls/Geosearch.js
@@ -206,7 +206,7 @@ EsriLeafletGeocoding.Controls.Geosearch = L.Control.extend({
       var result = results[i];
 
       // make sure bounds are valid and not 0,0. sometimes bounds are incorrect or not present
-      if(result.bounds.isValid() && !result.bounds.equals(nullIsland)){
+      if(result.bounds && result.bounds.isValid() && !result.bounds.equals(nullIsland)){
         bounds.extend(result.bounds);
       }
 

--- a/src/Providers/GeocodeService.js
+++ b/src/Providers/GeocodeService.js
@@ -5,8 +5,34 @@ EsriLeafletGeocoding.Controls.Geosearch.Providers.GeocodeService = EsriLeafletGe
   },
 
   suggestions: function(text, bounds, callback){
-    callback(undefined, []);
-    return false;
+
+    if (this.options.supportsSuggest) {
+      var request = this.suggest().text(text);
+      if(bounds){
+        request.within(bounds);
+      }
+
+      return request.run(function(error, results, response){
+        var suggestions = [];
+        if(!error){
+          while(response.suggestions.length && suggestions.length <= (this.options.maxResults - 1)){
+            var suggestion = response.suggestions.shift();
+            if(!suggestion.isCollection){
+              suggestions.push({
+                text: suggestion.text,
+                magicKey: suggestion.magicKey
+              });
+            }
+          }
+        }
+        callback(error, suggestions);
+      }, this);
+    }
+
+    else {
+      callback(undefined, []);
+      return false;
+    }
   },
 
   results: function(text, key, bounds, callback){

--- a/src/Services/Geocoding.js
+++ b/src/Services/Geocoding.js
@@ -18,10 +18,7 @@ EsriLeafletGeocoding.Services.Geocoding = Esri.Services.Service.extend({
   },
 
   suggest: function(){
-    if(this.options.url !== EsriLeafletGeocoding.WorldGeocodingService && !this.options.supportsSuggest && console && console.warn){
-      console.warn('Only the ArcGIS Online World Geocoder supports suggestions');
-      return;
-    }
+    // requires either the Esri World Geocoding Service or a 10.3 ArcGIS Server Geocoding Service that supports suggest.
     return new EsriLeafletGeocoding.Tasks.Suggest(this);
   },
 

--- a/src/Services/Geocoding.js
+++ b/src/Services/Geocoding.js
@@ -6,6 +6,7 @@ EsriLeafletGeocoding.Services.Geocoding = Esri.Services.Service.extend({
     options = options || {};
     options.url = options.url || EsriLeafletGeocoding.WorldGeocodingService;
     Esri.Services.Service.prototype.initialize.call(this, options);
+    this._confirmSuggestSupport();
   },
 
   geocode: function(){
@@ -17,11 +18,22 @@ EsriLeafletGeocoding.Services.Geocoding = Esri.Services.Service.extend({
   },
 
   suggest: function(){
-    if(this.options.url !== EsriLeafletGeocoding.WorldGeocodingService && console && console.warn){
+    if(this.options.url !== EsriLeafletGeocoding.WorldGeocodingService && !this.options.supportsSuggest && console && console.warn){
       console.warn('Only the ArcGIS Online World Geocoder supports suggestions');
       return;
     }
     return new EsriLeafletGeocoding.Tasks.Suggest(this);
+  },
+
+  _confirmSuggestSupport: function(){
+    this.metadata(function(error, response) {
+      if (response.capabilities.includes('Suggest')) {
+        this.options.supportsSuggest = true;
+      }
+      else {
+        this.options.supportsSuggest = false;
+      }
+    }, this);
   }
 });
 

--- a/src/Tasks/Geocode.js
+++ b/src/Tasks/Geocode.js
@@ -64,7 +64,9 @@ EsriLeafletGeocoding.Tasks.Geocode = Esri.Tasks.Task.extend({
 
     for (var i = 0; i < response.locations.length; i++) {
       var location = response.locations[i];
-      var bounds = Esri.Util.extentToBounds(location.extent);
+      if (location.extent) {
+        var bounds = Esri.Util.extentToBounds(location.extent);
+      }
 
       results.push({
         text: location.name,


### PR DESCRIPTION
closes #64

### whats included?
* fixed `FeatureLayer` provider instantiation syntax in 'debug/sample.html' (unrelated)
* a few copyedits in doc
* added a quick metadata request during initialization for the `Geocoding` service to determine whether or not 'Suggest' is a supported capability.
* added logic to the provider to hook things up

### to do:
- [x] test with a few more functioning geocoders to confirm all is well. (see [below](https://github.com/Esri/esri-leaflet-geocoder/pull/65#issuecomment-104377200))
- [x] make sure no more doc updates are required
- [x] figure out what to do when the geocoding service `find` operation can't match an address presented by its own `suggest` operation (i've seen this several times now)