### PR TITLE
provide option to detach search input from map itself [not ready]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ coverage
 # Debugging Files
 debug/*
 !debug/sample.html
+!debug/sample-no-map.html
 
 # Built Files
 dist/**/*.js

--- a/debug/sample-no-map.html
+++ b/debug/sample-no-map.html
@@ -27,54 +27,57 @@
         bottom: 0;
         left: 0;
         right: 0;
+      }
+
+      #page2 {
         display: none;
       }
 
-      /* currently not respected, and overrides suggestion text placement
       #wholegroup {
-        text-align: center !important;
-      }-->
-      */
-
-      .text-bar {
-        width: 400px;
+        display: inline-block;
+        width: 100%;
+        text-align: center;
       }
 
       .geocoder-control-input {
         position: relative;
+        width: 30%;
       }
 
       .geocoder-control-suggestions {
         position: relative;
         top: 0;
         max-height: 400px;
-        max-width: 400px;
+        max-width: 30%;
         font: 12px/1.5 "Helvetica Neue", Arial, Helvetica, sans-serif;
       }
     </style>
   </head>
   <body>
-
-    <h1>where would you like to go today?</h1>
     <form>
       <div id='wholegroup'>
+        <h1>where to?</h1>
         <!--label for="address">something funny:</label-->
-        <input class="text-bar" type="text" id="address" placeholder='ex. LAX'>
+        <input class="text-bar" type="text" id="address" placeholder="ex. LAX">
       </div>
     </form>
     <br><div id="results"></div>
-    <div id="map"></div>
+    <div id="page2">
+      <!--input type="button" id="again" value='again?'-->
+      <div id="map"></div>
+    </div>
     <script>
       var map = L.map('map').setView([37.74, -121.62], 9);
       L.esri.basemapLayer('Topographic').addTo(map);
       var search = L.esri.Geocoding.Controls.geosearch({
         inputTag: 'address',
-        placeholder: 'ex. LAX'
+        placeholder: 'ex. LAX',
+        expanded: true
       })// .addTo(map);
       search.onAdd(map);
 
-      search.on('results', function(evt){
-        document.getElementById('map').style.display = 'block';
+      search.on('results', function(){
+        document.getElementById('page2').style.display = 'block';
         // http://leafletjs.com/reference.html#map-invalidatesize
         map.invalidateSize();
       });

--- a/debug/sample-no-map.html
+++ b/debug/sample-no-map.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>geocode bareback</title>
+    <title>mapless geocoding</title>
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
 
     <!-- Load Leaflet from CDN-->
@@ -9,21 +9,15 @@
 
     <link rel="stylesheet" href="../src/esri-leaflet-geocoder.css" />
 
-    <!--script src="../node_modules/leaflet/dist/leaflet-src.js"></script-->
     <script src="//cdn.jsdelivr.net/leaflet/0.7.3/leaflet.js"></script>
-
     <script src="../node_modules/esri-leaflet/dist/esri-leaflet.js"></script>
 
     <script src="../src/EsriLeafletGeocoding.js"></script>
     <script src="../src/Tasks/Geocode.js"></script>
-    <!--script src="../src/Tasks/ReverseGeocode.js"></script-->
     <script src="../src/Tasks/Suggest.js"></script>
     <script src="../src/Services/Geocoding.js"></script>
     <script src="../src/Controls/Geosearch.js"></script>
     <script src="../src/Providers/ArcgisOnlineGeocoder.js"></script>
-    <!--script src="../src/Providers/FeatureLayer.js"></script>
-    <script src="../src/Providers/GeocodeService.js"></script>
-    <script src="../src/Providers/MapService.js"></script-->
 
     <!-- Make the map fill the entire page -->
     <style>
@@ -35,36 +29,55 @@
         right: 0;
         display: none;
       }
+
+      /* currently not respected, and overrides suggestion text placement
+      #wholegroup {
+        text-align: center !important;
+      }-->
+      */
+
       .text-bar {
         width: 400px;
+      }
+
+      .geocoder-control-input {
+        top: 80px;
+        left: 50px;
+      }
+
+      .geocoder-control-suggestions {
+        top: 106px; /* input + 26px */
+        left: 50px;
+        max-height: 50%;
+        max-width: 400px;
       }
     </style>
   </head>
   <body>
 
-    <h1>geocode with no map!</h1>
+    <h1>who needs a map</h1>
     <form>
       <div id='wholegroup'>
-        <!--label for="address">find a location:</label-->
+        <!--label for="address">something funny:</label-->
         <input class="text-bar" type="text" id="address">
-        <!--input type="button">search-->
       </div>
     </form>
     <br><div id="results"></div>
     <div id="map"></div>
     <script>
       var map = L.map('map').setView([37.74, -121.62], 9);
+      L.esri.basemapLayer('Topographic').addTo(map);
       var search = L.esri.Geocoding.Controls.geosearch({
         inputTag: 'address',
-        expanded: false,
         placeholder: '123 main st'
-      });
-      search.initialize();
+      })// .addTo(map);
       search.onAdd(map);
 
       search.on('results', function(evt){
-        document.getElementById('results').innerHTML = 'location of matched address is: ' + evt.results[0].latlng.lat + ', ' + evt.results[0].latlng.lng;
-      })
+        document.getElementById('map').style.display = 'block';
+        // http://leafletjs.com/reference.html#map-invalidatesize
+        map.invalidateSize();
+      });
     </script>
   </body>
 </html>

--- a/debug/sample-no-map.html
+++ b/debug/sample-no-map.html
@@ -41,25 +41,25 @@
       }
 
       .geocoder-control-input {
-        top: 80px;
-        left: 50px;
+        position: relative;
       }
 
       .geocoder-control-suggestions {
-        top: 106px; /* input + 26px */
-        left: 50px;
-        max-height: 50%;
+        position: relative;
+        top: 0;
+        max-height: 400px;
         max-width: 400px;
+        font: 12px/1.5 "Helvetica Neue", Arial, Helvetica, sans-serif;
       }
     </style>
   </head>
   <body>
 
-    <h1>who needs a map</h1>
+    <h1>where would you like to go today?</h1>
     <form>
       <div id='wholegroup'>
         <!--label for="address">something funny:</label-->
-        <input class="text-bar" type="text" id="address">
+        <input class="text-bar" type="text" id="address" placeholder='ex. LAX'>
       </div>
     </form>
     <br><div id="results"></div>
@@ -69,7 +69,7 @@
       L.esri.basemapLayer('Topographic').addTo(map);
       var search = L.esri.Geocoding.Controls.geosearch({
         inputTag: 'address',
-        placeholder: '123 main st'
+        placeholder: 'ex. LAX'
       })// .addTo(map);
       search.onAdd(map);
 

--- a/debug/sample-no-map.html
+++ b/debug/sample-no-map.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>geocode bareback</title>
+    <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
+
+    <!-- Load Leaflet from CDN-->
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/leaflet/0.7.3/leaflet.css" />
+
+    <link rel="stylesheet" href="../src/esri-leaflet-geocoder.css" />
+
+    <!--script src="../node_modules/leaflet/dist/leaflet-src.js"></script-->
+    <script src="//cdn.jsdelivr.net/leaflet/0.7.3/leaflet.js"></script>
+
+    <script src="../node_modules/esri-leaflet/dist/esri-leaflet.js"></script>
+
+    <script src="../src/EsriLeafletGeocoding.js"></script>
+    <script src="../src/Tasks/Geocode.js"></script>
+    <!--script src="../src/Tasks/ReverseGeocode.js"></script-->
+    <script src="../src/Tasks/Suggest.js"></script>
+    <script src="../src/Services/Geocoding.js"></script>
+    <script src="../src/Controls/Geosearch.js"></script>
+    <script src="../src/Providers/ArcgisOnlineGeocoder.js"></script>
+    <!--script src="../src/Providers/FeatureLayer.js"></script>
+    <script src="../src/Providers/GeocodeService.js"></script>
+    <script src="../src/Providers/MapService.js"></script-->
+
+    <!-- Make the map fill the entire page -->
+    <style>
+      #map {
+        position: fixed;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        display: none;
+      }
+      .text-bar {
+        width: 400px;
+      }
+    </style>
+  </head>
+  <body>
+
+    <h1>geocode with no map!</h1>
+    <form>
+      <div id='wholegroup'>
+        <!--label for="address">find a location:</label-->
+        <input class="text-bar" type="text" id="address">
+        <!--input type="button">search-->
+      </div>
+    </form>
+    <br><div id="results"></div>
+    <div id="map"></div>
+    <script>
+      var map = L.map('map').setView([37.74, -121.62], 9);
+      var search = L.esri.Geocoding.Controls.geosearch({
+        inputTag: 'address',
+        expanded: false,
+        placeholder: '123 main st'
+      });
+      search.initialize();
+      search.onAdd(map);
+
+      search.on('results', function(evt){
+        document.getElementById('results').innerHTML = 'location of matched address is: ' + evt.results[0].latlng.lat + ', ' + evt.results[0].latlng.lng;
+      })
+    </script>
+  </body>
+</html>

--- a/src/Controls/Geosearch.js
+++ b/src/Controls/Geosearch.js
@@ -1,15 +1,14 @@
 /*
 to do:
-remove the map instantiation entirely
-make height and width configurable?
-add back original css for element positions
-(and override when there is no map)
-make it so that you dont have to call onAdd (and maybe not even initialize)
-adapt the sample to zoom the map to the geocoded location automatically
+try to revert to use L.control and figure out how to override what Leaflet does to re-nest the divs in leaflet-control-container
+why isn't the font for suggestions in the css being picked up?
+how could you center align the input parent div?
+figure out why <label>s associated with the input tag are squished
+make it so youre not *forced* to declare input tag width manually
+why is the 'expanded' constructor option being ignored? (probably bound to leaflet-control-container css)
 
-show all this to pat and ask him
- 1. whether its okay that i extended L.Class instead
- 2. whether i need to decouple the css which provides style
+bigger picture
+ if/how might this benefit from a more substantial reorganization
 */
 
 EsriLeafletGeocoding.Controls.Geosearch = L.Class.extend({
@@ -187,11 +186,6 @@ EsriLeafletGeocoding.Controls.Geosearch = L.Class.extend({
     if (this._attachToMap){
       this._suggestions.style.maxHeight = (this._map.getSize().y - this._suggestions.offsetTop - this._wrapper.offsetTop - 10) + 'px';
     }
-    else {
-      // need to figure out how to make all this configurable
-      this._suggestions.style.maxHeight = '20%';
-      this._suggestions.style.maxWidth = '30%';
-    }
 
     var nodes = [];
     var list;
@@ -277,9 +271,16 @@ EsriLeafletGeocoding.Controls.Geosearch = L.Class.extend({
       this._input.title = this.options.title;
     }
     else {
-      this._wrapper = document.getElementById('wholegroup');
+      this._input = document.getElementById(this.options.inputTag);
+
+      if (this._input.parentNode){
+        this._wrapper = this._input.parentNode;
+      }
+      // else {
+      //   // something like http://stackoverflow.com/questions/11601028/create-a-parent-div-for-the-selected-element
+      // }
+
       this._wrapper.className = 'geocoder-control ' + ((this.options.expanded) ? ' ' + 'geocoder-control-expanded' : '');
-      this._input = document.getElementById('address');
       this._input.className += ' geocoder-control-input leaflet-bar';
       this._input.title = this.options.title;
     }

--- a/src/Controls/Geosearch.js
+++ b/src/Controls/Geosearch.js
@@ -1,4 +1,18 @@
-EsriLeafletGeocoding.Controls.Geosearch = L.Control.extend({
+/*
+to do:
+remove the map instantiation entirely
+make height and width configurable?
+add back original css for element positions
+(and override when there is no map)
+make it so that you dont have to call onAdd (and maybe not even initialize)
+adapt the sample to zoom the map to the geocoded location automatically
+
+show all this to pat and ask him
+ 1. whether its okay that i extended L.Class instead
+ 2. whether i need to decouple the css which provides style
+*/
+
+EsriLeafletGeocoding.Controls.Geosearch = L.Class.extend({
   includes: L.Mixin.Events,
   options: {
     position: 'topleft',
@@ -27,6 +41,10 @@ EsriLeafletGeocoding.Controls.Geosearch = L.Control.extend({
       for (var i = 0; i < this.options.providers.length; i++) {
         this.options.providers[i].options.maxResults = this.options.maxResults;
       }
+    }
+
+    if (this.options.inputTag){
+      this._attachToMap = false;
     }
 
     this._pendingSuggestions = [];
@@ -159,12 +177,21 @@ EsriLeafletGeocoding.Controls.Geosearch = L.Control.extend({
     var currentGroup;
     this._suggestions.style.display = 'block';
 
+
+
     // set the maxHeight of the suggestions box to
     // map height
     // - suggestions offset (distance from top of suggestions to top of control)
     // - control offset (distance from top of control to top of map)
     // - 10 (extra padding)
-    this._suggestions.style.maxHeight = (this._map.getSize().y - this._suggestions.offsetTop - this._wrapper.offsetTop - 10) + 'px';
+    if (this._attachToMap){
+      this._suggestions.style.maxHeight = (this._map.getSize().y - this._suggestions.offsetTop - this._wrapper.offsetTop - 10) + 'px';
+    }
+    else {
+      // need to figure out how to make all this configurable
+      this._suggestions.style.maxHeight = '20%';
+      this._suggestions.style.maxWidth = '30%';
+    }
 
     var nodes = [];
     var list;
@@ -244,9 +271,18 @@ EsriLeafletGeocoding.Controls.Geosearch = L.Control.extend({
       }
     }
 
-    this._wrapper = L.DomUtil.create('div', 'geocoder-control ' + ((this.options.expanded) ? ' ' + 'geocoder-control-expanded'  : ''));
-    this._input = L.DomUtil.create('input', 'geocoder-control-input leaflet-bar', this._wrapper);
-    this._input.title = this.options.title;
+    if (this._attachToMap){
+      this._wrapper = L.DomUtil.create('div', 'geocoder-control ' + ((this.options.expanded) ? ' ' + 'geocoder-control-expanded' : ''));
+      this._input = L.DomUtil.create('input', 'geocoder-control-input leaflet-bar', this._wrapper);
+      this._input.title = this.options.title;
+    }
+    else {
+      this._wrapper = document.getElementById('wholegroup');
+      this._wrapper.className = 'geocoder-control ' + ((this.options.expanded) ? ' ' + 'geocoder-control-expanded' : '');
+      this._input = document.getElementById('address');
+      this._input.className += ' geocoder-control-input leaflet-bar';
+      this._input.title = this.options.title;
+    }
 
     this._suggestions = L.DomUtil.create('div', 'geocoder-control-suggestions leaflet-bar', this._wrapper);
 

--- a/src/Controls/Geosearch.js
+++ b/src/Controls/Geosearch.js
@@ -1,16 +1,3 @@
-/*
-to do:
-try to revert to use L.control and figure out how to override what Leaflet does to re-nest the divs in leaflet-control-container
-why isn't the font for suggestions in the css being picked up?
-how could you center align the input parent div?
-figure out why <label>s associated with the input tag are squished
-make it so youre not *forced* to declare input tag width manually
-why is the 'expanded' constructor option being ignored? (probably bound to leaflet-control-container css)
-
-bigger picture
- if/how might this benefit from a more substantial reorganization
-*/
-
 EsriLeafletGeocoding.Controls.Geosearch = L.Class.extend({
   includes: L.Mixin.Events,
   options: {

--- a/src/esri-leaflet-geocoder.css
+++ b/src/esri-leaflet-geocoder.css
@@ -1,4 +1,7 @@
 .geocoder-control-input {
+  position: absolute;
+  left: 0;
+  top: 0;
   background-color: white;
   background-repeat: no-repeat;
   background-image: url("img/search.png");
@@ -61,6 +64,8 @@ only screen and (min-device-pixel-ratio: 2) {
 .geocoder-control-suggestions {
   width: 100%;
   position: absolute;
+  top: 26px;
+  left: 0;
   margin-top: 10px;
   overflow: auto;
   display: none;

--- a/src/esri-leaflet-geocoder.css
+++ b/src/esri-leaflet-geocoder.css
@@ -1,7 +1,4 @@
 .geocoder-control-input {
-  position: absolute;
-  left: 0;
-  top: 0;
   background-color: white;
   background-repeat: no-repeat;
   background-image: url("img/search.png");
@@ -64,8 +61,6 @@ only screen and (min-device-pixel-ratio: 2) {
 .geocoder-control-suggestions {
   width: 100%;
   position: absolute;
-  top: 26px;
-  left: 0;
   margin-top: 10px;
   overflow: auto;
   display: none;


### PR DESCRIPTION
would resolve #32

working sample [here](https://github.com/jgravois/esri-leaflet-geocoder/blob/input-form/debug/sample-no-map.html)
#### to do:
- [ ] revert to use `L.control` again and figure out how to override what Leaflet does to re-nest the divs in leaflet-control-container
- [ ] figure out how to center .geocoder-input-suggestions on page while keeping the actual text left aligned.
- [x] why isn't the font for suggestions in the css being picked up? (via aa138a3405e4659bacb17794ae839ea9b4ba1bcb)
- [x] how could you `text-align: center` the input parent div? (via 36881b63b17a1c69a6be1b3ba5a08c3b5c7c26ce)
- [x] figure out why `<label>`s associated with the input tag are currently being squished
- [ ] ~~make it so you're not *forced* to declare the input tag width manually~~
- [x] why is the 'expanded' constructor option being ignored? (because we were hardcoding the input tag width)

#### bigger picture
- [ ] see if/how might this benefit from a more substantial reorganization
