### PR TITLE
1.0.0 refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
+before_install: npm install -g grunt-cli
 node_js:
   - "0.10"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.0.0
+
+This represents the stable release of Esri Leaflet Geocoder compatible with Leaflet 0.7.3. All future 1.0.X releases will be compatible with Leaflet 0.7.3 and contain only bug fixes. New features will only be added in Esri Leaflet Geocoder 2.0.0 which will require Leaflet 1.0.0.
+
+#### Changes
+
+* Introduced support for dynamic suggestions from custom geocoding services. #65
+* Refactored code to account for changes introduced in Esri Leaflet `1.0.0`. #75
+* Fixed problem in `initialize` #63 (thanks @timwis!)
+* Plugin now dynamically sets a hard search extent when `useMapBounds` is set to true. #58
+
 ## Release Candidate 3
 
 #### Breaking Changes
@@ -70,7 +81,7 @@ Please read through the docs and changes list carefully. There has been a major 
 ## Beta 2
 
 * Fix bug in IE 10 and 11 on Windows 8 touch devices
- 
+
 ## Beta 1
 
 This is now ready for beta! This release helps finalize the API and includes lots of cross browser support.

--- a/debug/sample.html
+++ b/debug/sample.html
@@ -45,11 +45,11 @@
       L.esri.Geocoding.Controls.geosearch({
         providers: [
           new L.esri.Geocoding.Controls.Geosearch.Providers.FeatureLayer({
-            url: 'https://services.arcgis.com/uCXeTVveQzP4IIcx/arcgis/rest/services/GIS_Day/FeatureServer/0',
-            searchFields: ['EventName', 'Organizati'],
-            label: 'GIS Day Events',
+            url: 'http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/2',
+            searchFields: ['NAME', 'STATE_NAME'],
+            label: 'US Counties',
             formatSuggestion: function(feature){
-              return feature.properties.EventName + ' - ' + feature.properties.Organizati;
+              return feature.properties.NAME;
             }
           })
         ]

--- a/index.html
+++ b/index.html
@@ -61,12 +61,12 @@
             searchFields: ['NAME', 'STATE_NAME']
           }),
           new L.esri.Geocoding.Controls.Geosearch.Providers.FeatureLayer({
-            url: 'http://services.arcgis.com/uCXeTVveQzP4IIcx/arcgis/rest/services/gisday/FeatureServer/0/',
-            searchFields: ['Name', 'Organization'],
-            label: 'GIS Day Events',
+            url: 'http://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer/0/',
+            searchFields: ['CITY_NAME'],
+            label: 'World Cities',
             bufferRadius: 5000,
             formatSuggestion: function(feature){
-              return feature.properties.Name + ' - ' + feature.properties.Organization;
+              return feature.properties.CITY_NAME + ' - Population: ' + feature.properties.POP;
             }
           })
         ]

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "url": "git@github.com:Esri/esri-leaflet-geocoder.git"
   },
   "scripts": {
-    "prepublish": "node -e \"require('grunt').tasks(['prepublish']);\"",
-    "test": "node -e \"require('grunt').tasks(['test']);\""
+    "prepublish": "grunt prepublish",
+    "test": "grunt test"
   },
   "devDependencies": {
     "grunt": "~0.4.1",
@@ -41,7 +41,7 @@
   "license": "Apache 2.0",
   "readmeFilename": "README.md",
   "dependencies": {
-    "leaflet": "0.7.3",
+    "leaflet": "^0.7.3",
     "esri-leaflet": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esri-leaflet-geocoder",
-  "version": "1.0.0-rc.3",
+  "version": "1.0.0",
   "description": "Esri Geocoding utilities and search plguin for Leaflet.",
   "homepage": "https://github.com/Esri/esri-leaflet-geocoder",
   "main": "dist/esri-leaflet-geocoder.js",
@@ -35,12 +35,13 @@
   },
   "author": "Patrick Arlt <parlt@esri.com> (http://patrickarlt.com)",
   "contributors": [
-    "Patrick Arlt <parlt@esri.com> (http://patrickarlt.com)"
+    "Patrick Arlt <parlt@esri.com> (http://patrickarlt.com)",
+    "John Gravois <jgravois@esri.com> (http://johngravois.com)"
   ],
   "license": "Apache 2.0",
   "readmeFilename": "README.md",
   "dependencies": {
-    "leaflet": "^0.7.0",
-    "esri-leaflet": "^1.0.0-rc.5"
+    "leaflet": "0.7.3",
+    "esri-leaflet": "^1.0.0"
   }
 }

--- a/src/Providers/FeatureLayer.js
+++ b/src/Providers/FeatureLayer.js
@@ -1,4 +1,4 @@
-EsriLeafletGeocoding.Controls.Geosearch.Providers.FeatureLayer = L.esri.Services.FeatureLayer.extend({
+EsriLeafletGeocoding.Controls.Geosearch.Providers.FeatureLayer = L.esri.Services.FeatureLayerService.extend({
   options: {
     label: 'Feature Layer',
     maxResults: 5,
@@ -7,8 +7,9 @@ EsriLeafletGeocoding.Controls.Geosearch.Providers.FeatureLayer = L.esri.Services
       return feature.properties[this.options.searchFields[0]];
     }
   },
-  initialize: function(url, options){
-    L.esri.Services.FeatureLayer.prototype.initialize.call(this, url, options);
+  initialize: function(options){
+    options.url = L.esri.Util.cleanUrl(options.url);
+    L.esri.Services.FeatureLayerService.prototype.initialize.call(this, options);
     L.Util.setOptions(this, options);
     if(typeof this.options.searchFields === 'string'){
       this.options.searchFields = [this.options.searchFields];

--- a/src/Providers/MapService.js
+++ b/src/Providers/MapService.js
@@ -8,8 +8,8 @@ EsriLeafletGeocoding.Controls.Geosearch.Providers.MapService = L.esri.Services.M
       return feature.properties[feature.displayFieldName] + ' <small>' + feature.layerName + '</small>';
     }
   },
-  initialize: function(url, options){
-    L.esri.Services.MapService.prototype.initialize.call(this, url, options);
+  initialize: function(options){
+    L.esri.Services.MapService.prototype.initialize.call(this, options);
     this._getIdFields();
   },
   suggestions: function(text, bounds, callback){


### PR DESCRIPTION
closes #74 

had to ditch the GIS day feature service because it doesn't look like its up anymore.

in the middle of refactoring i noticed that developers have to `new` up their 'Provider' objects because we don't do 
```js
EsriLeafletGeocoding.Controls.Geosearch.Providers.featureLayer = function(options){
  return new EsriLeafletGeocoding.Controls.Geosearch.Providers.FeatureLayer;
};
```
is that an intentional deviation?