### PR TITLE
Fixes response.capabilities undefined error when using custom geocoder without ArcGIS Online Geoocoder.

### DIFF
--- a/src/Services/Geocoding.js
+++ b/src/Services/Geocoding.js
@@ -24,7 +24,7 @@ EsriLeafletGeocoding.Services.Geocoding = Esri.Services.Service.extend({
 
   _confirmSuggestSupport: function(){
     this.metadata(function(error, response) {
-      if (response.capabilities.includes('Suggest')) {
+      if (response.capabilities && response.capabilities.includes('Suggest')) {
         this.options.supportsSuggest = true;
       }
       else {


### PR DESCRIPTION
The latest update to the plugin breaks because the response.capabilities is undefined on an ArcGIS Server 10.2 custom geocode service. This appears to fix the issue.

I've created a [gist](https://gist.github.com/npeihl/f37c81e311158cccbb32) showing how the debug/sample.html would look with our custom geocode service. I didn't include my changes to debug/sample.html in the commit.