### PR TITLE
Country and category filtering for ArcGIS Online Geocoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Option | Type | Default | Description
 
 Option | Type | Default | Description
 --- | --- | --- | ---
-`countries` | `String` `Array[Strings]` | false | Limit results to one or more countries. Any ISO 3166 2 or 3 digit [country code supported by the ArcGIS World Geocode service](https://developers.arcgis.com/rest/geocode/api-reference/geocode-coverage.htm) is allowed.
+`countries` | `String` `Array[Strings]` | false | Limit results to one or more countries. Any ISO 3166 2 or 3 digit [country code supported by the ArcGIS World Geocode service](https://developers.arcgis.com/rest/geocode/api-reference/geocode-coverage.htm) is allowed. *Note* using an array of country codes may not result in inaccurate results even when a specific suggestion is supplied.
 `categories` | `String` `Array[Strings]` | false | Limit results to one or more categories. See the [list of valid categories](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-category-filtering.htm#ESRI_SECTION1_502B3FE2028145D7B189C25B1A00E17B) for possible values.
 
 Results from the `arcgisOnlineProvider` will have an additional `properties` key which will correspond with [all available fields on the ArcGIS Online World Geocode service](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-service-output.htm#ESRI_SECTION1_42D7D3D0231241E9B656C01438209440)

--- a/README.md
+++ b/README.md
@@ -146,37 +146,77 @@ L.esri.Geocoding.Controls.geosearch({
 * `L.esri.Geocoding.mapServiceProvider(options)` - Uses the find and query methods on the Map Service to get text matches.
 * `L.esri.Geocoding.geocodeServiceProvider` - Use an ArcGIS Server Geocode Service, supports suggestions if available with ARcGIS Server 10.3 and up.
 
-#### Provider Options
+#### Providers
+
+All providers share following options:
 
 Option | Type | Default | Description
 --- | --- | --- | ---
-`url` | `String` | Depends | The URL for the service that will be used to search. Varies by provider, usually a service or layer URL or a geocoding service URL. Not needed with the `arcgisOnlineProvider`.
-`searchFields` | `Array[Strings]` | None | An array of fields to search for text. Not valid for the `arcgisOnlineProvider` and `geocodeServiceProvider` providers.
-`layer` | `Integer` | `0` | Only valid for `mapServiceProvider` providers, the layer to find text matches on.
-`label` | `String` | Provider Type | Text that will be used to group suggestions under when more than one provider is being used.
+`label` | `String` | Varies by Provider | Text that will be used to group suggestions under when more than one provider is being used.
 `maxResults` | `Integer` | 5 | Maximum number of results to show for this provider.
-`bufferRadius`, | `Integer` | If a service or layer contains points, buffer points by this radius to create bounds. Not valid for the `arcgisOnlineProvider` and `geocodeServiceProvider`.
+`attribution` | `String` | Varies by Provider | Adds an attribution to the map.
+
+##### `arcgisOnlineProvider`
+
+Option | Type | Default | Description
+--- | --- | --- | ---
+`countries` | `String` `Array[Strings]` | false | Limit results to one or more countries. Any ISO 3166 2 or 3 digit [country code supported by the ArcGIS World Geocode service](https://developers.arcgis.com/rest/geocode/api-reference/geocode-coverage.htm) is allowed.
+`categories` | `String` `Array[Strings]` | false | Limit results to one or more categories. See the [list of valid categories](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-category-filtering.htm#ESRI_SECTION1_502B3FE2028145D7B189C25B1A00E17B) for possible values.
+
+Results from the `arcgisOnlineProvider` will have an additional `properties` key which will correspond with [all available fields on the ArcGIS Online World Geocode service](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-service-output.htm#ESRI_SECTION1_42D7D3D0231241E9B656C01438209440)
+
+##### `geocodeServiceProvider`
+
+Option | Type | Default | Description
+--- | --- | --- | ---
+`url` | `String` | *Required* | The URL for the service that will be searched.
+`label` | `String` | `'Geocode Service'` | Text that will be used to group suggestions under when more than one provider is being used.
+`maxResults` | `Integer` | 5 | Maximum number of results to show for this provider.
+
+Results from the `geocodeServiceProvider` will have an additional `properties` key which will correspond with all the available fields in the service.
+
+##### `featureLayerProvider`
+
+Option | Type | Default | Description
+--- | --- | --- | ---
+`url` | `String` | *Required* | The URL for the service that will be searched.
+`searchFields` | `String` `Array[Strings]` | None | An array of fields to search for text.
 `formatSuggestion`| `Function` | See Description | Formatting function for the suggestion text. Receives feature information and returns a string.
+`bufferRadius`, | `Integer` | If a service or layer contains points, buffer points by this radius to create bounds.
+
+Results from the `featureLayerProvider` will have an additional `properties` key which will contain all the information for the feature and a `geojson` key that will contain a [GeoJSON](http://geojson.org/) representation of the feature.
+
+##### `mapServiceProvider`
+
+Option | Type | Default | Description
+--- | --- | --- | ---
+`url` | `String` | *Required* | The URL for the service that will be searched.
+`searchFields` | `String` `Array[Strings]` | None | An array of fields to search for text.
+`layer` | `Integer` | `0` | The layer to find text matches on. Can also be an array of layer identifiers.
+`formatSuggestion`| `Function` | See Description | Formatting function for the suggestion text. Receives feature information and returns a string.
+`bufferRadius`, | `Integer` `Array[Integers]`| Buffer point results by this radius to create bounds.
+
+Results from the `mapServiceProvider` will have an additional `properties` key which will contain all the information for the feature and a `geojson` key that will contain a [GeoJSON](http://geojson.org/) representation of the feature.
 
 #### Results Event
 
 Property | Type | Description
 --- | --- | ---
 `bounds` | [`L.LatLngBounds`](http://leafletjs.com/reference.html#latlngbounds)| The bounds around this suggestion. Good for zooming to results like cities and states.
-`latlng` | [`L.LatLng`](http://leafletjs.com/reference.html#latlng)| The center of the result.
+`latlng` | [`L.LatLng`](http://leafletjs.com/reference.html#latlng)| The center of the results.
 `results` | [`[<ResultObject>]`](#result-object) | An array of [result objects](#result-object).
 
 #### Result Object
 
-A single result from the geocoder. You should not rely on all these properties being present in every result object.
+A single result from a provider. You should not rely on all these properties being present in every result object and some providers may add additional properties.
 
 Property | Type | Description
 --- | --- | ---
-`text` | `String` | The text that was passed to the geocoder.
-`bounds` | [`L.LatLngBounds`](http://leafletjs.com/reference.html#latlngbounds)| The bounds around this suggestion. Good for zooming to results like cities and states.
+`text` | `String` | The text that was passed to the provider.
+`bounds` | [`L.LatLngBounds`](http://leafletjs.com/reference.html#latlngbounds)| The bounds around this result. Good for zooming to results like cities and states.
 `latlng` | [`L.LatLng`](http://leafletjs.com/reference.html#latlng)| The center of the result.
 
-The result object will also contain any additional properties from the provider. So when geocoding you will also get address breakdowns and when text matching features you will get the additional fields from that feature.
+The result object will also contain any additional properties from the provider. See the [available providers](#available-providers) for which additional fields may be present.
 
 ## L.esri.Geocoding.geocodeService
 A basic wrapper for ArcGIS Online geocoding services. Used internally by `L.esri.Geocoding.geosearch`.

--- a/debug/sample.html
+++ b/debug/sample.html
@@ -10,18 +10,9 @@
 
     <script src="../node_modules/esri-leaflet/dist/esri-leaflet.js"></script>
 
-    <link rel="stylesheet" href="../src/esri-leaflet-geocoder.css" />
+    <link rel="stylesheet" href="../dist/esri-leaflet-geocoder.css" />
+    <script src="../dist/esri-leaflet-geocoder.js"></script>
 
-    <script src="../src/EsriLeafletGeocoding.js"></script>
-    <script src="../src/Tasks/Geocode.js"></script>
-    <script src="../src/Tasks/ReverseGeocode.js"></script>
-    <script src="../src/Tasks/Suggest.js"></script>
-    <script src="../src/Services/Geocoding.js"></script>
-    <script src="../src/Controls/Geosearch.js"></script>
-    <script src="../src/Providers/ArcgisOnlineGeocoder.js"></script>
-    <script src="../src/Providers/FeatureLayer.js"></script>
-    <script src="../src/Providers/GeocodeService.js"></script>
-    <script src="../src/Providers/MapService.js"></script>
 
     <!-- Make the map fill the entire page -->
     <style>
@@ -42,15 +33,11 @@
 
       var tiles = L.esri.basemapLayer('Topographic').addTo(map);
 
-      L.esri.Geocoding.Controls.geosearch({
+      L.esri.Geocoding.geosearch({
         providers: [
-          new L.esri.Geocoding.Controls.Geosearch.Providers.FeatureLayer({
-            url: 'http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/2',
-            searchFields: ['NAME', 'STATE_NAME'],
-            label: 'US Counties',
-            formatSuggestion: function(feature){
-              return feature.properties.NAME;
-            }
+          L.esri.Geocoding.arcgisOnlineProvider({
+            countries: ['USA', 'GUM', 'VIR', 'PRI'],
+            categories: ['Address', 'Postal', 'Populated Place', ]
           })
         ]
       }).addTo(map);

--- a/src/Controls/Geosearch.js
+++ b/src/Controls/Geosearch.js
@@ -207,18 +207,27 @@ export var Geosearch = L.Control.extend({
     }
 
     var nullIsland = L.latLngBounds([0, 0], [0, 0]);
-    var bounds = new L.LatLngBounds();
+    var resultBounds = [];
+    var resultLatlngs = [];
 
+    // collect the bounds and center of each result
     for (var i = results.length - 1; i >= 0; i--) {
       var result = results[i];
 
+      resultLatlngs.push(result.latlng);
+
       // make sure bounds are valid and not 0,0. sometimes bounds are incorrect or not present
       if (result.bounds && result.bounds.isValid() && !result.bounds.equals(nullIsland)) {
-        bounds.extend(result.bounds);
+        resultBounds.push(result.bounds);
       }
+    }
 
-      // ensure that the bounds include the results center point
-      bounds.extend(result.latlng);
+    // form a bounds object containing all center points
+    var bounds = L.latLngBounds(resultLatlngs);
+
+    // and extend it to contain all bounds objects
+    for (var j = 0; j < resultBounds.length; j++) {
+      bounds.extend(resultBounds[i]);
     }
 
     return bounds;

--- a/src/Providers/ArcgisOnlineGeocoder.js
+++ b/src/Providers/ArcgisOnlineGeocoder.js
@@ -4,7 +4,12 @@ export var ArcgisOnlineProvider = GeocodeService.extend({
   options: {
     label: 'Places and Addresses',
     maxResults: 5,
-    attribution: '<a href="https://developers.arcgis.com/en/features/geocoding/">Geocoding by Esri</a>'
+    attribution: '<a href="https://developers.arcgis.com/en/features/geocoding/">Geocoding by Esri</a>',
+
+    /*
+    countries: ['USA']
+    categories: ['Pizza']
+    */
   },
 
   suggestions: function (text, bounds, callback) {
@@ -12,6 +17,14 @@ export var ArcgisOnlineProvider = GeocodeService.extend({
 
     if (bounds) {
       request.within(bounds);
+    }
+
+    if (this.options.countries) {
+      request.countries(this.options.countries);
+    }
+
+    if (this.options.categories) {
+      request.category(this.options.categories);
     }
 
     return request.run(function (error, results, response) {

--- a/src/Providers/ArcgisOnlineGeocoder.js
+++ b/src/Providers/ArcgisOnlineGeocoder.js
@@ -4,12 +4,7 @@ export var ArcgisOnlineProvider = GeocodeService.extend({
   options: {
     label: 'Places and Addresses',
     maxResults: 5,
-    attribution: '<a href="https://developers.arcgis.com/en/features/geocoding/">Geocoding by Esri</a>',
-
-    /*
-    countries: ['USA']
-    categories: ['Pizza']
-    */
+    attribution: '<a href="https://developers.arcgis.com/en/features/geocoding/">Geocoding by Esri</a>'
   },
 
   suggestions: function (text, bounds, callback) {

--- a/src/Providers/FeatureLayer.js
+++ b/src/Providers/FeatureLayer.js
@@ -75,7 +75,8 @@ export var FeatureLayerProvider = FeatureLayerService.extend({
             latlng: bounds.getCenter(),
             bounds: bounds,
             text: this.options.formatSuggestion.call(this, feature),
-            properties: feature.properties
+            properties: feature.properties,
+            geojson: feature
           };
 
           results.push(result);

--- a/src/Providers/MapService.js
+++ b/src/Providers/MapService.js
@@ -70,12 +70,15 @@ export var MapServiceProvider = MapService.extend({
             feature.layerId = layer;
             feature.layerName = this._layerNames[layer];
             feature.displayFieldName = this._displayFields[layer];
+
             var result = {
               latlng: bounds.getCenter(),
               bounds: bounds,
               text: this.options.formatSuggestion.call(this, feature),
-              properties: feature.properties
+              properties: feature.properties,
+              geojson: feature
             };
+            
             results.push(result);
           }
         }

--- a/src/Tasks/Suggest.js
+++ b/src/Tasks/Suggest.js
@@ -9,7 +9,8 @@ export var Suggest = Task.extend({
 
   setters: {
     text: 'text',
-    category: 'category'
+    category: 'category',
+    countries: 'countryCode'
   },
 
   initialize: function (options) {


### PR DESCRIPTION
* Implement a `countries` option for `arcgisOnlineProvider` https://github.com/Esri/esri-leaflet-geocoder/issues/38
* Implement a `categories` option for `arcgisOnlineProvider`
* `countries` method on `Suggest`
* add `result.geojson` for `featureLayerProvider` and `mapServiceProvider` https://github.com/Esri/esri-leaflet-geocoder/issues/81
* refactor result bounds calculation to avoid `new` https://github.com/Esri/esri-leaflet-geocoder/issues/84

This is waiting on:

* [x] Changelog updates
* [x] Tests for `countries` on Suggest
* [x] Doc for  `countries` on Suggest
* [ ] Confirmation from the geocoding team that (contrary to the docs) you do not need to add countries in the corresponding `find` request after a suggestion.