### PR TITLE
fix language input and add returnIntersection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-### [Unreleased]
+## [Unreleased]
+
+### Added
+
+* exposed a parameter in `reverseGeocode` requests to fetch intersections.
+
+### Fixed
+
+* appropriate l18n input parameter is now passed in `reverseGeocode` requests
 
 ## [2.0.1]
 

--- a/README.md
+++ b/README.md
@@ -375,13 +375,14 @@ Method | Returns | Description
 --- | --- | ---
 `latlng(latlng <L.LatLng>)` | The L.LatLng object for which the address will be looked up.
 `distance(distance <Integer>)` | The distance (in meters) around the point for which addresses will be looked up.
-`language(language <String>)` | `this` | The language to return the address in.
+`language(langCode <String>)` | `this` | The language to return the address in. More information can be found [here](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-reverse-geocode.htm#ESRI_SECTION1_ABD1AD449DF54FFEB9527A606341714C).
+`intersection(returnIntersection <Boolean>)` | `this` | Set this value to `true` if you'd like the nearest intersection to be returned (Default value is `false`).
 `run(callback <Function>, context <Object>)` | `XMLHttpRequest` | Executes this request chain and accepts the response callback.
 
 ### Example
 
 ```js
-L.esri.Geocoding.reverseGeocode().latlng([48.8583,  2.2945]).run(function(error, result, response){
+L.esri.Geocoding.reverseGeocode().intersection(true).latlng([48.8583,  2.2945]).run(function(error, result, response){
   // callback is called with error, result, and response.
   // result.latlng contains the latlng of the located address
   // result.address contains the address information

--- a/spec/Tasks/ReverseGeocodeSpec.js
+++ b/spec/Tasks/ReverseGeocodeSpec.js
@@ -99,7 +99,7 @@ describe('L.esri.ReverseGeocode', function () {
       done();
     });
 
-    expect(request.url).to.contain('language=fr');
+    expect(request.url).to.contain('langCode=fr');
 
     request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, sampleFrenchResponse);
   });

--- a/src/Tasks/ReverseGeocode.js
+++ b/src/Tasks/ReverseGeocode.js
@@ -6,12 +6,14 @@ export var ReverseGeocode = Task.extend({
   path: 'reverseGeocode',
 
   params: {
-    outSR: 4326
+    outSR: 4326,
+    returnIntersection: false
   },
 
   setters: {
     'distance': 'distance',
-    'language': 'language'
+    'language': 'langCode',
+    'intersection': 'returnIntersection'
   },
 
   initialize: function (options) {


### PR DESCRIPTION
resolves #105

when i looked at the code i realized we weren't setting [`langCode`](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-reverse-geocode.htm#ESRI_SECTION1_ABD1AD449DF54FFEB9527A606341714C) correctly either so i fixed that, updated the relevant test and got info into the doc.