### PR TITLE
Add a searchBounds attribute to geocoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Option | Type | Default | Description
 `position` | `String` | `topleft` | One of the valid Leaflet [control positions](http://leafletjs.com/reference.html#control-positions).
 `zoomToResult` | `Boolean` | `true` | If `true` the map will zoom the result after geocoding is complete.
 `useMapBounds` | `Boolean` or <br> `Integer` | `12` | Determines if and when the geocoder should begin using the bounds of the map to enchance search results. If `true` the geocoder will always return results in the current map bounds. If `false` it will always search the world. If an integer like `11` is passed in the geocoder will use the bounds of the map for searching if the map is at a zoom level equal to or greater than the integer. This mean the geocoder will prefer local results when the map is zoomed in.
+`searchBounds` | `L.latLngBounds` | `null` | If set, the geocoder will filter results using the provided static bounding box regardless of the current zoom level of the map (ie: supercedes useMapBounds).
 `collapseAfterResult` | `Boolean` | `true` | If the geocoder is expanded after a result this will collapse it.
 `expanded` | `Boolean` | `false` | Start the control in an expanded state.
 `allowMultipleResults` | `Boolean` | `true` | If set to `true` and the user submits the form without a suggestion selected geocodes the current text in the input and zooms the user to view all the results.

--- a/spec/Controls/GeosearchSpec.js
+++ b/spec/Controls/GeosearchSpec.js
@@ -19,6 +19,24 @@ describe('L.esri.Geosearch', function () {
 
   var map = createMap();
 
+  beforeEach(function(){
+    this.xhr = sinon.useFakeXMLHttpRequest();
+    var requests = this.requests = [];
+
+    this.xhr.onCreate = function (xhr) {
+        requests.push(xhr);
+    };
+
+  });
+
+  afterEach(function(){
+    this.xhr.restore();
+  });
+
+  var southWest = L.latLng(29.30, -99.71);
+  var northEast = L.latLng(31.34, -95.57);
+  var mapbounds = L.latLngBounds(southWest, northEast);
+
   it('shouldnt overwrite custom options set in the constructor', function() {
     var geosearch = L.esri.Geocoding.geosearch({
         providers: [
@@ -30,7 +48,8 @@ describe('L.esri.Geosearch', function () {
         expanded: true,
         allowMultipleResults: false,
         placeholder: 'something clever',
-        title: 'something not so clever'
+        title: 'something not so clever',
+        searchBounds: mapbounds
     });
 
     expect(geosearch.options.useMapBounds).to.equal(false);
@@ -40,6 +59,7 @@ describe('L.esri.Geosearch', function () {
     expect(geosearch.options.allowMultipleResults).to.equal(false);
     expect(geosearch.options.placeholder).to.equal('something clever');
     expect(geosearch.options.title).to.equal('something not so clever');
+    expect(geosearch.options.searchBounds).to.equal(mapbounds);
   });
 
 
@@ -53,4 +73,23 @@ describe('L.esri.Geosearch', function () {
     expect(map.attributionControl._container.innerHTML).to.contain('Geocoding by Esri');
   });
 
+  it('should correctly build the searchExtent for the provider', function (done) {
+    var geosearch = L.esri.Geocoding.geosearch({
+        providers: [
+          L.esri.Geocoding.arcgisOnlineProvider()
+        ],
+        searchBounds:mapbounds
+    }).addTo(map);
+
+    geosearch._suggest("Mayoworth, WY");
+    var request = geosearch._pendingSuggestions[0];
+    expect(request).to.be.an.instanceof(XMLHttpRequest);
+
+    this.requests[0].respond(200, { "Content-Type": "application/json" },
+                                 JSON.stringify({"suggestions":[]}));
+
+    expect(geosearch._pendingSuggestions[0].url).to.equal('http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/suggest?text=Mayoworth%2C%20WY&location=-97.64%2C30.32&distance=50000&searchExtent=%7B%22xmin%22%3A-101.78%2C%22ymin%22%3A28.28%2C%22xmax%22%3A-93.5%2C%22ymax%22%3A32.36%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&f=json');
+    done();
+
+  });
 });

--- a/src/Controls/Geosearch.js
+++ b/src/Controls/Geosearch.js
@@ -6,6 +6,7 @@ export var Geosearch = L.Control.extend({
   options: {
     position: 'topleft',
     zoomToResult: true,
+    searchBounds: null,
     useMapBounds: 12,
     collapseAfterResult: true,
     expanded: false,
@@ -146,6 +147,10 @@ export var Geosearch = L.Control.extend({
   },
 
   _searchBounds: function () {
+    if (this.options.searchBounds !== null) {
+      return this.options.searchBounds;
+    }
+
     if (this.options.useMapBounds === false) {
       return null;
     }


### PR DESCRIPTION
As stated.  Relates to #113.  
I couldn't figure out how to capture the request URL from the request XMLHTMLrequest object for the tests.  Does anyone have any ideas about the best approach?

 - [x] Fix the tests to check the request url.