### PR TITLE
make sure geosearch control aggregates result extents correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## [Upcoming changes][Unreleased]
 
-## [2.0.4]
-
-
-
 ## [2.0.3]
 
 ### Added
@@ -178,7 +174,7 @@ This is now ready for beta! This release helps finalize the API and includes lot
 
 * Initial alpha release
 
-[Unreleased]: https://github.com/Esri/esri-leaflet-geocoder/compare/v2.0.2...HEAD
+[Unreleased]: https://github.com/Esri/esri-leaflet-geocoder/compare/v2.0.3...HEAD
 [2.0.3]: https://github.com/Esri/esri-leaflet-geocoder/compare/v2.0.2...v2.0.3
 [2.0.2]: https://github.com/Esri/esri-leaflet-geocoder/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/Esri/esri-leaflet-geocoder/compare/v2.0.0...v2.0.1

--- a/spec/Controls/GeosearchSpec.js
+++ b/spec/Controls/GeosearchSpec.js
@@ -1,6 +1,4 @@
-
 describe('L.esri.Geosearch', function () {
-
   function createMap(){
     // create container
     var container = document.createElement('div');
@@ -8,7 +6,7 @@ describe('L.esri.Geosearch', function () {
     // give container a width/height
     container.setAttribute('style', 'width:500px; height: 500px;');
 
-    // add contianer to body
+    // add container to body
     document.body.appendChild(container);
 
     return L.map(container, {
@@ -89,6 +87,39 @@ describe('L.esri.Geosearch', function () {
                                  JSON.stringify({"suggestions":[]}));
 
     expect(geosearch._pendingSuggestions[0].url).to.equal('http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/suggest?text=Mayoworth%2C%20WY&location=-97.64%2C30.32&distance=50000&searchExtent=%7B%22xmin%22%3A-101.78%2C%22ymin%22%3A28.28%2C%22xmax%22%3A-93.5%2C%22ymax%22%3A32.36%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&f=json');
+    done();
+
+  });
+
+  it('should correctly construct a bounds object around all inputs using each extent', function (done) {
+    var geosearch = L.esri.Geocoding.geosearch({
+        providers: [
+          L.esri.Geocoding.arcgisOnlineProvider()
+        ]
+    }).addTo(map);
+
+    var sampleTexasResults = [{
+      bounds: L.latLngBounds([37.200439, -93.300607], [25.300439, -105.200607]),
+      latlng: {
+        lat: 31.250439204000486,
+        lng: -99.25060627399967
+      },
+      properties: {
+        "Loc_name": "Gaz.WorldGazetteer.POI1",
+        "Score": 100,
+        "Match_addr": "Texas, United States",
+        "Addr_type": "POI",
+        "Type": "State or Province",
+        "PlaceName": "Texas"
+      },
+      score: 100,
+      text: 'Texas, United States'
+    }]
+    var aggBounds = geosearch._boundsFromResults(sampleTexasResults);
+    expect(aggBounds._northEast.lat).to.equal(37.200439);
+    expect(aggBounds._northEast.lng).to.equal(-93.300607);
+    expect(aggBounds._southWest.lat).to.equal(25.300439);
+    expect(aggBounds._southWest.lng).to.equal(-105.200607);
     done();
 
   });

--- a/spec/Tasks/GeocodeSpec.js
+++ b/spec/Tasks/GeocodeSpec.js
@@ -27,7 +27,7 @@ describe('L.esri.Geocode', function () {
     ]
   });
 
-  var sampleFindAddressCanidatesResponse = JSON.stringify({
+  var samplefindAddressCandidatesResponse = JSON.stringify({
     'spatialReference': {
       'wkid': 4326,
       'latestWkid': 4326
@@ -264,7 +264,7 @@ describe('L.esri.Geocode', function () {
     request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, sampleFindResponse);
   });
 
-  it('should make a findAddressCanidates request to ArcGIS Online', function (done) {
+  it('should make a findAddressCandidates request to ArcGIS Online', function (done) {
     var request = new L.esri.Geocoding.geocode().address('380 New York St').city('Redlands').region('California').postal(92373).run(function (err, response) {
       expect(response.results[0].latlng.lat).to.equal(34.056490727765947);
       expect(response.results[0].latlng.lng).to.equal(-117.19566584280369);
@@ -280,10 +280,10 @@ describe('L.esri.Geocode', function () {
     expect(request.url).to.contain('region=California');
     expect(request.url).to.contain('postal=92373');
 
-    request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, sampleFindAddressCanidatesResponse);
+    request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, samplefindAddressCandidatesResponse);
   });
 
-  it('should make a findAddressCanidates request to a Geocode Service', function (done) {
+  it('should make a findAddressCandidates request to a Geocode Service', function (done) {
     var request = new L.esri.Geocoding.geocode({
       url: 'http://gis.example.com/arcgis/rest/services/Geocoder'
     }).address('380 New York St').city('Redlands').region('California').postal(92373).run(function (err, response) {
@@ -301,7 +301,7 @@ describe('L.esri.Geocode', function () {
     expect(request.url).to.contain('region=California');
     expect(request.url).to.contain('postal=92373');
 
-    request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, sampleFindAddressCanidatesResponse);
+    request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, samplefindAddressCandidatesResponse);
   });
 
   it('should make a `within` request to ArcGIS Online', function (done) {

--- a/src/Controls/Geosearch.js
+++ b/src/Controls/Geosearch.js
@@ -233,7 +233,7 @@ export var Geosearch = L.Control.extend({
 
     // and extend it to contain all bounds objects
     for (var j = 0; j < resultBounds.length; j++) {
-      bounds.extend(resultBounds[i]);
+      bounds.extend(resultBounds[j]);
     }
 
     return bounds;


### PR DESCRIPTION
can't believe no one else reported this.

STR: 
1. launch the geosearch [sample](http://esri.github.io/esri-leaflet/examples/geocoding-control.html)
2. type, `texas` and accept the first match.
3. the map zooms in to street level even though the geocoding result includes [an extent](http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/find?outSr=4326&forStorage=false&outFields=*&maxLocations=20&text=Texas%2C%20United%20States&magicKey=GST7YMc0AM9UOsE9HhFtGTyVGST7YMc0AM9UOsE9DbTVHgA9HhB0Zcp0OhNtGMytaikZU5NJU5kHUoc4Hhp0OSTaSsEqAZ43AP9zJikuGPAmIYxQGPT-CZc0YiD7DsKJCZyAOh5-Dn47Z5EGOhtvY1FF&bbox=%7B%22xmin%22%3A-99.2531704902649%2C%22ymin%22%3A31.249291241150125%2C%22xmax%22%3A-99.2480367422104%2C%22ymax%22%3A31.251584282844966%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&f=pjson) for the whole state.

```js
"extent": {
  "xmin": -105.20060700000001,
  "ymin": 25.300439000000001,
  "xmax": -93.300606999999999,
  "ymax": 37.200439000000003
},
```
just needed to use the correct variable in the second `for` loop within `_boundsFromResults()`
