### PR TITLE
ensure 'maxResults' limits the number of suggestions too

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "semistandard": "^7.0.5",
     "sinon": "^1.11.1",
     "sinon-chai": "2.7.0",
-    "uglify-js": "^2.6.1"
+    "uglify-js": "^2.6.1",
+    "watch": "^0.17.1"
   },
   "homepage": "https://github.com/Esri/esri-leaflet-geocoder",
   "jsnext:main": "src/EsriLeafletGeocoding.js",
@@ -62,7 +63,7 @@
     "prepublish": "npm run build",
     "pretest": "npm run build",
     "release": "./scripts/release.sh",
-    "start": "nodemon --watch src --exec 'npm run build' & http-server -p 5678 -c-1 -o",
+    "start": "watch 'npm run build' src & http-server -p 5678 -c-1 -o",
     "test": "npm run lint && karma start"
   },
   "style": "./dist/esri-leaflet-geocoder.css"

--- a/spec/Controls/GeosearchSpec.js
+++ b/spec/Controls/GeosearchSpec.js
@@ -74,7 +74,9 @@ describe('L.esri.Geosearch', function () {
   it('should correctly build the searchExtent for the provider', function (done) {
     var geosearch = L.esri.Geocoding.geosearch({
         providers: [
-          L.esri.Geocoding.arcgisOnlineProvider()
+          L.esri.Geocoding.arcgisOnlineProvider({
+            maxResults: 6
+          })
         ],
         searchBounds:mapbounds
     }).addTo(map);
@@ -86,7 +88,7 @@ describe('L.esri.Geosearch', function () {
     this.requests[0].respond(200, { "Content-Type": "application/json" },
                                  JSON.stringify({"suggestions":[]}));
 
-    expect(geosearch._geosearchCore._pendingSuggestions[0].url).to.equal('https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/suggest?text=Mayoworth%2C%20WY&location=-97.64%2C30.32&distance=50000&searchExtent=%7B%22xmin%22%3A-101.78%2C%22ymin%22%3A28.28%2C%22xmax%22%3A-93.5%2C%22ymax%22%3A32.36%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&f=json');
+    expect(geosearch._geosearchCore._pendingSuggestions[0].url).to.equal('https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/suggest?text=Mayoworth%2C%20WY&location=-97.64%2C30.32&distance=50000&searchExtent=%7B%22xmin%22%3A-101.78%2C%22ymin%22%3A28.28%2C%22xmax%22%3A-93.5%2C%22ymax%22%3A32.36%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&maxSuggestions=6&f=json');
     done();
 
   });

--- a/spec/Tasks/GeocodeSpec.js
+++ b/spec/Tasks/GeocodeSpec.js
@@ -348,4 +348,18 @@ describe('L.esri.Geocode', function () {
     request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, sampleFindNearbyResponse);
   });
 
+  it('should send the correct params to the right operation for custom geocoding services', function (done) {
+    var request = L.esri.Geocoding.geocode({
+      url: 'http://tasks.arcgisonline.com/ArcGIS/rest/services/Locators/TA_Address_NA_10/GeocodeServer',
+      customParam: 'SingleLine'
+    }).text('Highlands Ranch').run(function (err, response) {
+      done();
+    });
+
+    expect(request.url).to.contain('//tasks.arcgisonline.com/ArcGIS/rest/services/Locators/TA_Address_NA_10/GeocodeServer/findAddressCandidates');
+    expect(request.url).to.contain('SingleLine=Highlands%20Ranch');
+
+    request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, samplefindAddressCandidatesResponse);
+  });
+
 });

--- a/src/Providers/ArcgisOnlineGeocoder.js
+++ b/src/Providers/ArcgisOnlineGeocoder.js
@@ -22,6 +22,11 @@ export var ArcgisOnlineProvider = GeocodeService.extend({
       request.category(this.options.categories);
     }
 
+    // 15 is the maximum number of suggestions that can be returned
+    if (this.options.maxResults) {
+      request.maxSuggestions(this.options.maxResults);
+    }
+
     return request.run(function (error, results, response) {
       var suggestions = [];
       if (!error) {

--- a/src/Services/Geocode.js
+++ b/src/Services/Geocode.js
@@ -7,9 +7,14 @@ import suggest from '../Tasks/Suggest';
 export var GeocodeService = Service.extend({
   initialize: function (options) {
     options = options || {};
-    options.url = options.url || WorldGeocodingServiceUrl;
-    Service.prototype.initialize.call(this, options);
-    this._confirmSuggestSupport();
+    if (options.url) {
+      Service.prototype.initialize.call(this, options);
+      this._confirmSuggestSupport();
+    } else {
+      options.url = WorldGeocodingServiceUrl;
+      options.supportsSuggest = true;
+      Service.prototype.initialize.call(this, options);
+    }
   },
 
   geocode: function () {

--- a/src/Services/Geocode.js
+++ b/src/Services/Geocode.js
@@ -37,7 +37,7 @@ export var GeocodeService = Service.extend({
       // since, only SOME individual services have been configured to support asking for suggestions
       if (!response.capabilities) {
         this.options.supportsSuggest = false;
-        this.options.singleLineParam = response.singleLineAddressField.name;
+        this.options.customParam = response.singleLineAddressField.name;
       } else if (response.capabilities.indexOf('Suggest') > -1) {
         this.options.supportsSuggest = true;
       } else {

--- a/src/Services/Geocode.js
+++ b/src/Services/Geocode.js
@@ -21,14 +21,19 @@ export var GeocodeService = Service.extend({
   },
 
   suggest: function () {
-    // requires either the Esri World Geocoding Service or a 10.3 ArcGIS Server Geocoding Service that supports suggest.
+    // requires either the Esri World Geocoding Service or a <10.3 ArcGIS Server Geocoding Service that supports suggest.
     return suggest(this);
   },
 
   _confirmSuggestSupport: function () {
     this.metadata(function (error, response) {
       if (error) { return; }
-      if (response.capabilities.indexOf('Suggest') > -1) {
+      // pre 10.3 geocoding services dont list capabilities (and dont support maxLocations)
+      // since, only SOME individual services have been configured to support asking for suggestions
+      if (!response.capabilities) {
+        this.options.supportsSuggest = false;
+        this.options.singleLineParam = response.singleLineAddressField.name;
+      } else if (response.capabilities.indexOf('Suggest') > -1) {
         this.options.supportsSuggest = true;
       } else {
         this.options.supportsSuggest = false;

--- a/src/Tasks/Geocode.js
+++ b/src/Tasks/Geocode.js
@@ -30,15 +30,8 @@ export var Geocode = Task.extend({
   },
 
   initialize: function (options) {
-    if (typeof options !== 'undefined') {
-      this.path = 'findAddressCandidates';
-      if (options.options) {
-        options = options.options;
-      }
-    } else {
-      options = options || {};
-      options.url = options.url || WorldGeocodingServiceUrl;
-    }
+    options = options || {};
+    options.url = options.url || WorldGeocodingServiceUrl;
     Task.prototype.initialize.call(this, options);
   },
 
@@ -56,8 +49,9 @@ export var Geocode = Task.extend({
   },
 
   run: function (callback, context) {
-    if (this.options.singleLineParam) {
-      this.params[this.options.singleLineParam] = this.params.text;
+    if (this.options.customParam) {
+      this.path = 'findAddressCandidates';
+      this.params[this.options.customParam] = this.params.text;
       delete this.params.text;
     } else {
       this.path = (this.params.text) ? 'find' : 'findAddressCandidates';

--- a/src/Tasks/Geocode.js
+++ b/src/Tasks/Geocode.js
@@ -30,12 +30,14 @@ export var Geocode = Task.extend({
   },
 
   initialize: function (options) {
-    if (typeof options !== 'undefined' && options.options) {
-      options = options.options;
+    if (typeof options !== 'undefined') {
       this.path = 'findAddressCandidates';
+      if (options.options) {
+        options = options.options;
+      }
     } else {
       options = options || {};
-      options.url || WorldGeocodingServiceUrl;
+      options.url = options.url || WorldGeocodingServiceUrl;
     }
     Task.prototype.initialize.call(this, options);
   },

--- a/src/Tasks/Geocode.js
+++ b/src/Tasks/Geocode.js
@@ -30,8 +30,13 @@ export var Geocode = Task.extend({
   },
 
   initialize: function (options) {
-    options = options || {};
-    options.url = options.url || WorldGeocodingServiceUrl;
+    if (typeof options !== 'undefined' && options.options) {
+      options = options.options;
+      this.path = 'findAddressCandidates';
+    } else {
+      options = options || {};
+      options.url || WorldGeocodingServiceUrl;
+    }
     Task.prototype.initialize.call(this, options);
   },
 
@@ -49,7 +54,12 @@ export var Geocode = Task.extend({
   },
 
   run: function (callback, context) {
-    this.path = (this.params.text) ? 'find' : 'findAddressCandidates';
+    if (this.options.singleLineParam) {
+      this.params[this.options.singleLineParam] = this.params.text;
+      delete this.params.text;
+    } else {
+      this.path = (this.params.text) ? 'find' : 'findAddressCandidates';
+    }
 
     if (this.path === 'findAddressCandidates' && this.params.bbox) {
       this.params.searchExtent = this.params.bbox;
@@ -91,7 +101,9 @@ export var Geocode = Task.extend({
 
     for (var i = 0; i < response.candidates.length; i++) {
       var candidate = response.candidates[i];
-      var bounds = Util.extentToBounds(candidate.extent);
+      if (candidate.extent) {
+        var bounds = Util.extentToBounds(candidate.extent);
+      }
 
       results.push({
         text: candidate.address,

--- a/src/Tasks/Suggest.js
+++ b/src/Tasks/Suggest.js
@@ -10,12 +10,13 @@ export var Suggest = Task.extend({
   setters: {
     text: 'text',
     category: 'category',
-    countries: 'countryCode'
+    countries: 'countryCode',
+    maxSuggestions: 'maxSuggestions'
   },
 
-  initialize: function (options) {
-    options = options || {};
-    options.url = options.url || WorldGeocodingServiceUrl;
+  initialize: function (provider) {
+    var options = provider.options || {};
+    options.url = provider.options.url || WorldGeocodingServiceUrl;
     Task.prototype.initialize.call(this, options);
   },
 

--- a/src/Tasks/Suggest.js
+++ b/src/Tasks/Suggest.js
@@ -14,9 +14,9 @@ export var Suggest = Task.extend({
     maxSuggestions: 'maxSuggestions'
   },
 
-  initialize: function (provider) {
-    var options = provider.options || {};
-    options.url = provider.options.url || WorldGeocodingServiceUrl;
+  initialize: function (options) {
+    options = options || {};
+    options.url = options.url || WorldGeocodingServiceUrl;
     Task.prototype.initialize.call(this, options);
   },
 

--- a/src/Tasks/Suggest.js
+++ b/src/Tasks/Suggest.js
@@ -16,7 +16,10 @@ export var Suggest = Task.extend({
 
   initialize: function (options) {
     options = options || {};
-    options.url = options.url || WorldGeocodingServiceUrl;
+    if (!options.url) {
+      options.url = WorldGeocodingServiceUrl;
+      options.supportsSuggest = true;
+    }
     Task.prototype.initialize.call(this, options);
   },
 
@@ -39,9 +42,13 @@ export var Suggest = Task.extend({
   },
 
   run: function (callback, context) {
-    return this.request(function (error, response) {
-      callback.call(context, error, response, response);
-    }, this);
+    if (this.options.supportsSuggest) {
+      return this.request(function (error, response) {
+        callback.call(context, error, response, response);
+      }, this);
+    } else {
+      console.warn('this geocoding service does not support asking for suggestions');
+    }
   }
 
 });


### PR DESCRIPTION
i would expect setting `maxResults` to impact how many *suggestions* are returned, not geocoding matches. 

right now, even though 'L.esri.geosearch' passes along a `maxResults` parameter when ultimately calling the `find` operation of the World Geocoding Service, since a `magicKey` is included too, only one candidate is ever going to come back.

this code change has the desired effect of exposing a technique to augment the number of suggestions returned, but needs a little more testing to make sure all is well with the other providers.