### PR TITLE
use `indexOf` instead of `includes` for old ie

### DIFF
--- a/src/Services/Geocode.js
+++ b/src/Services/Geocode.js
@@ -28,7 +28,7 @@ export var GeocodeService = Service.extend({
   _confirmSuggestSupport: function () {
     this.metadata(function (error, response) {
       if (error) { return; }
-      if (response.capabilities.includes('Suggest')) {
+      if (response.capabilities.indexOf('Suggest') > -1) {
         this.options.supportsSuggest = true;
       } else {
         this.options.supportsSuggest = false;


### PR DESCRIPTION
i reproed a user reported error in IE11 with geosearch and the stock World Geocoding Service provider.

since that browser doesn't support `String.includes()`, altered the check to use the logic below instead.
```js
if (string.indexOf('foo') > -1) 
  // proceed
```