### PR TITLE
display 'Powered by Esri

### DIFF
--- a/debug/sample.html
+++ b/debug/sample.html
@@ -29,7 +29,10 @@
 
     <script>
       var map = L.map('map').setView([37.74, -121.62], 9);
-      var tiles = L.esri.basemapLayer('Topographic').addTo(map);
+      // var tiles = L.esri.basemapLayer('Topographic').addTo(map);
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: '&copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors'
+      }).addTo(map);
 
       var searchControl = L.esri.Geocoding.geosearch({
         providers: [

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "John Gravois <jgravois@esri.com> (http://johngravois.com)"
   ],
   "dependencies": {
-    "esri-leaflet": "^2.0.0",
-    "leaflet": "^1.0.0-rc.1"
+    "esri-leaflet": "^2.0.3",
+    "leaflet": "^1.0.0-rc.3"
   },
   "devDependencies": {
     "chai": "2.3.0",

--- a/spec/Controls/GeosearchSpec.js
+++ b/spec/Controls/GeosearchSpec.js
@@ -68,7 +68,7 @@ describe('L.esri.Geosearch', function () {
         ]
     }).addTo(map);
 
-    expect(map.attributionControl._container.innerHTML).to.contain('Geocoding by Esri');
+    expect(map.attributionControl._container.innerHTML).to.contain('Powered by');
   });
 
   it('should correctly build the searchExtent for the provider', function (done) {

--- a/src/Controls/Geosearch.js
+++ b/src/Controls/Geosearch.js
@@ -1,5 +1,6 @@
 import L from 'leaflet';
 import { geosearchCore } from '../Classes/GeosearchCore';
+import { Util } from 'esri-leaflet';
 
 export var Geosearch = L.Control.extend({
   includes: L.Mixin.Events,
@@ -165,6 +166,9 @@ export var Geosearch = L.Control.extend({
   },
 
   onAdd: function (map) {
+    // include 'Powered by Esri' in map attribution
+    Util.setEsriAttribution(map);
+
     this._map = map;
     this._wrapper = L.DomUtil.create('div', 'geocoder-control ' + ((this.options.expanded) ? ' ' + 'geocoder-control-expanded' : ''));
     this._input = L.DomUtil.create('input', 'geocoder-control-input leaflet-bar', this._wrapper);

--- a/src/Providers/ArcgisOnlineGeocoder.js
+++ b/src/Providers/ArcgisOnlineGeocoder.js
@@ -3,8 +3,7 @@ import { GeocodeService } from '../Services/Geocode';
 export var ArcgisOnlineProvider = GeocodeService.extend({
   options: {
     label: 'Places and Addresses',
-    maxResults: 5,
-    attribution: '<a href="https://developers.arcgis.com/en/features/geocoding/">Geocoding by Esri</a>'
+    maxResults: 5
   },
 
   suggestions: function (text, bounds, callback) {


### PR DESCRIPTION
resolves #132 by ensuring consistent usage of 'Powered by Esri' when the ArcGIS Online World Geocoding service is referenced.

this shouldn't be merged until we tag a new esri-leaflet release.