### PR TITLE
expose option to filter the features in featureLayer that will return a match

### DIFF
--- a/src/Providers/FeatureLayer.js
+++ b/src/Providers/FeatureLayer.js
@@ -95,7 +95,11 @@ export var FeatureLayerProvider = FeatureLayerService.extend({
       queryString.push(field + " LIKE upper('%" + text + "%')");
     }
 
-    return queryString.join(' OR ');
+    if (this.options.where) {
+      return this.options.where + ' AND ' + queryString.join(' OR ');
+    } else {
+      return queryString.join(' OR ');
+    }
   },
 
   _featureBounds: function (feature) {


### PR DESCRIPTION
resolves #135

```js
L.esri.Geocoding.featureLayerProvider({
  label: 'States',
  url: 'http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/3',
  searchFields: ['STATE_NAME'],
  // only return a match if the searched state population exceeds 10 million
  where: 'POP2007 > 10000000'
})
```