### PR TITLE
2.1.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,5 @@ debug/*
 !debug/sample.html
 
 # Built Files and watch cache
-dist
+dist/
 build

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Take a look at the [live demo](http://esri.github.com/esri-leaflet/examples/geoc
     <!-- Esri Leaflet -->
     <script src="https://cdn.jsdelivr.net/leaflet.esri/2.0.3/esri-leaflet.js"></script>
     <!-- Esri Leaflet Geocoder -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.2/esri-leaflet-geocoder.css">
-    <script src="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.2/esri-leaflet-geocoder.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.3/esri-leaflet-geocoder.css">
+    <script src="https://cdn.jsdelivr.net/leaflet.esri.geocoder/2.1.3/esri-leaflet-geocoder.js"></script>
     <!-- Make the map fill the entire page -->
     <style>
     #map {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esri-leaflet-geocoder",
   "description": "Esri Geocoding utility and search plugin for Leaflet.",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "author": "Patrick Arlt <parlt@esri.com> (http://patrickarlt.com)",
   "contributors": [
     "Patrick Arlt <parlt@esri.com> (http://patrickarlt.com)",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,14 +4,14 @@
 VERSION=$(node --eval "console.log(require('./package.json').version);")
 NAME=$(node --eval "console.log(require('./package.json').name);")
 
+# run prepublish to build files
+npm run prepublish
+
 # build and test
 npm test || exit 1
 
 # checkout temp branch for release
 git checkout -b gh-release
-
-# run prepublish to build files
-npm run prepublish
 
 # force add files
 git add dist -f


### PR DESCRIPTION
for some reason, the last npm release was missing the `.css` file.

based on looking at the teminal log, my hope is that the manual call to `npm run prepublish` in the release script might have been in the middle of overwriting the file when the actual publish happened.

kinda weird that it never happened before, but whatevs.  here goes take 2.