### PR TITLE
clear loading icon when no matches are returned

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "prepublish": "npm run build",
     "pretest": "npm run build",
     "release": "./scripts/release.sh",
-    "start": "watch \"npm run build\" src | http-server -p 5678 -c-1 -o",
+    "start": "watch \"npm run build\" src & http-server -p 5678 -c-1 -o",
     "test": "npm run lint && karma start"
   },
   "style": "./dist/esri-leaflet-geocoder.css"

--- a/src/Classes/GeosearchCore.js
+++ b/src/Classes/GeosearchCore.js
@@ -80,10 +80,13 @@ export var GeosearchCore = L.Evented.extend({
           return;
         }
 
-        if (suggestions) {
+        if (suggestions.length) {
           for (i = 0; i < suggestions.length; i++) {
             suggestions[i].provider = provider;
           }
+        } else {
+          // we still need to update the UI
+          this._control._renderSuggestions(suggestions);
         }
 
         if (provider._lastRender !== text && provider.nodes) {

--- a/src/Controls/Geosearch.js
+++ b/src/Controls/Geosearch.js
@@ -317,10 +317,6 @@ export var Geosearch = L.Control.extend({
     }, this);
 
     return this._wrapper;
-  },
-
-  onRemove: function (map) {
-    map.attributionControl.removeAttribution('Geocoding by Esri');
   }
 });
 


### PR DESCRIPTION
this change ensures that the UI is updated appropriately in situations where the last request for suggestions returns no matches.

resolves #141 

additional, unrelated changes:
* the control no longer invokes custom attribution, so the onRemove() method is no longer necessary.
* switched back from the UNIX pipe (|) operator to single ampersand for concurrent commands because only 'npm run css' was being called when a change was made to source.