### PR TITLE
Remove contains parameter from mapserver provider

### DIFF
--- a/src/Providers/MapService.js
+++ b/src/Providers/MapService.js
@@ -54,7 +54,7 @@ export var MapServiceProvider = MapService.extend({
       var layer = key.split(':')[1];
       request = this.query().layer(layer).featureIds(featureId);
     } else {
-      request = this.find().text(text).fields(this.options.searchFields).contains(false).layers(this.options.layers);
+      request = this.find().text(text).fields(this.options.searchFields).layers(this.options.layers);
     }
 
     return request.run(function (error, features, response) {


### PR DESCRIPTION
When false, the contains parameter requires the search text to match
exactly, even being case-sensitive. Removing this parameter will allow
fuzzy searches to go through. For example, type "king" and press enter 
on the debug page to return Kings, King, Kingman, ... counties from 
the map service.

I'm bypassing the suggestions in this example because as a user I'd expect 
the search to work similarly to a Google search (pressing enter returns results). 
See the attached gif. 

![esri-leaflet-geocoder](https://cloud.githubusercontent.com/assets/1638483/19120860/40be6e78-8ad9-11e6-8075-a93e3abfa210.gif)

ref: #148 
