### PR TITLE
fixed `npm start` working on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "mkdirp": "^0.5.1",
     "mocha": "^2.3.4",
     "node-sass": "^3.2.0",
+    "parallelshell": "^2.0.0",
     "phantomjs": "^1.9.17",
     "rollup": "^0.25.4",
     "rollup-plugin-json": "^2.0.0",
@@ -63,7 +64,8 @@
     "prepublish": "npm run build",
     "pretest": "npm run build",
     "release": "./scripts/release.sh",
-    "start": "watch \"npm run build\" src & http-server -p 5678 -c-1 -o",
+    "start-watch": "watch \"npm run build\" src",
+    "start": "parallelshell \"npm run start-watch\" \"http-server -p 5678 -c-1 -o\"",
     "test": "npm run lint && karma start"
   },
   "style": "./dist/esri-leaflet-geocoder.css"


### PR DESCRIPTION
addresses #131 

using [parallelshell](https://www.npmjs.com/package/parallelshell) to make this work cross-platform.

This works for me on Windows 7.

@jmfolds @jgravois can you please test on your platforms? Thanks!