### PR TITLE
clear objectIds from query after results are returned

### DIFF
--- a/src/Providers/FeatureLayer.js
+++ b/src/Providers/FeatureLayer.js
@@ -81,6 +81,9 @@ export var FeatureLayerProvider = FeatureLayerService.extend({
           };
 
           results.push(result);
+
+          // clear query parameters for the next search
+          delete this._resultsQuery.params['objectIds'];
         }
       }
       callback(error, results);


### PR DESCRIPTION
resolves #161

i tested with the others as well and the issue was definitely peculiar to `featureLayerProvider`.