### PR TITLE
stop accidently blowing away user supplied options

### DIFF
--- a/spec/Controls/GeosearchSpec.js
+++ b/spec/Controls/GeosearchSpec.js
@@ -60,6 +60,22 @@ describe('L.esri.Geosearch', function () {
     expect(geosearch.options.searchBounds).to.equal(mapbounds);
   });
 
+  it('even if no provider is passed', function() {
+    var geosearch = L.esri.Geocoding.geosearch({
+        useMapBounds: false,
+        zoomToResult: false,
+        collapseAfterResult: false,
+        expanded: true,
+        allowMultipleResults: false,
+        placeholder: 'something clever',
+        title: 'something not so clever',
+        searchBounds: mapbounds
+    });
+
+    expect(geosearch._geosearchCore.options.useMapBounds).to.equal(false);
+    expect(geosearch._geosearchCore.options.searchBounds).to.equal(mapbounds);
+  });
+
 
   it('should update map attribution when the World Geocoding Service is used', function() {
     var geosearch = L.esri.Geocoding.geosearch({

--- a/src/Controls/Geosearch.js
+++ b/src/Controls/Geosearch.js
@@ -19,7 +19,9 @@ export var Geosearch = L.Control.extend({
     L.Util.setOptions(this, options);
 
     if (!options || !options.providers || !options.providers.length) {
-      options = {};
+      if (!options) {
+        options = {};
+      }
       options.providers = [ arcgisOnlineProvider() ];
     }
 


### PR DESCRIPTION
resolves #165 

there's probably a clever*er* way to do this, but this change ensures that we pass through user supplied options to `geosearchCore` when the default provider is utilized.