### PR TITLE
tweak touchscreen widths slightly

### DIFF
--- a/src/Controls/Geosearch.js
+++ b/src/Controls/Geosearch.js
@@ -42,8 +42,10 @@ export var Geosearch = L.Control.extend({
 
   _renderSuggestions: function (suggestions) {
     var currentGroup;
-    this._suggestions.style.display = 'block';
 
+    if (suggestions.length > 0) {
+      this._suggestions.style.display = 'block';
+    }
     // set the maxHeight of the suggestions box to
     // map height
     // - suggestions offset (distance from top of suggestions to top of control)

--- a/src/esri-leaflet-geocoder.css
+++ b/src/esri-leaflet-geocoder.css
@@ -136,7 +136,7 @@ only screen and (min-device-pixel-ratio: 2) {
 /* styles when on a touch device */
 
 .leaflet-touch .geocoder-control {
-  width: 30px;
+  width: 34px;
   height: 30px;
 }
 
@@ -152,6 +152,7 @@ only screen and (min-device-pixel-ratio: 2) {
 
 .leaflet-touch .geocoder-control-suggestions {
   top: 30px;
+  width: 271px;
 }
 
 /* styles when browser is old and busted */


### PR DESCRIPTION
resolves #160 

* don't render suggestions when the service doesn't return any
* bump width of contracted and expanded control (to account for borders) on browsers that support touch (like Chrome [55](https://blog.chromium.org/2016/10/chrome-55-beta-input-handling.html))

i'm gonna chew on this a bit before i merge because i'd like to think we can preserve `box-shadow` in Chrome instead.