### PR TITLE
enable touch selection for results

### DIFF
--- a/src/Providers/ArcgisOnlineGeocoder.js
+++ b/src/Providers/ArcgisOnlineGeocoder.js
@@ -32,6 +32,7 @@ export var ArcgisOnlineProvider = GeocodeService.extend({
           if (!suggestion.isCollection) {
             suggestions.push({
               text: suggestion.text,
+              unformattedText: suggestion.text,
               magicKey: suggestion.magicKey
             });
           }

--- a/src/Providers/FeatureLayer.js
+++ b/src/Providers/FeatureLayer.js
@@ -42,6 +42,7 @@ export var FeatureLayerProvider = FeatureLayerService.extend({
           var feature = results.features[i];
           suggestions.push({
             text: this.options.formatSuggestion.call(this, feature),
+            unformattedText: feature.properties[this.options.searchFields[0]],
             magicKey: feature.id
           });
         }

--- a/src/Providers/GeocodeService.js
+++ b/src/Providers/GeocodeService.js
@@ -21,6 +21,7 @@ export var GeocodeServiceProvider = GeocodeService.extend({
             if (!suggestion.isCollection) {
               suggestions.push({
                 text: suggestion.text,
+                unformattedText: suggestion.text,
                 magicKey: suggestion.magicKey
               });
             }

--- a/src/Providers/MapService.js
+++ b/src/Providers/MapService.js
@@ -36,6 +36,7 @@ export var MapServiceProvider = MapService.extend({
           if (idField) {
             suggestions.push({
               text: this.options.formatSuggestion.call(this, feature),
+              unformattedText: feature.properties[feature.displayFieldName],
               magicKey: result.attributes[idField] + ':' + layer
             });
           }


### PR DESCRIPTION
fix for #186 (only tested on Chrome's mobile emulator)

also caught a bug in which formatted display text was incorrectly passed back to the service in feature searches and another bug that manifested when users click or tap on the `<small>` context text instead of the actual string so i fixed those too.

`ex: San Bernardino <small>Detailed Counties</small>`