### PR TITLE
fix travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ node_js:
 cache:
 directories:
 - node_modules
+services:
+  - xvfb
 before_script:
   - npm prune
   - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
 before_install:
   - google-chrome-stable --headless --disable-gpu
 addons:


### PR DESCRIPTION
we're getting invalid errors in travis (on #221 for example) - `The command "sh -e /etc/init.d/xvfb start" failed and exited with 127 during .` - this config change should fix that.

per [here](https://benlimmer.com/2019/01/14/travis-ci-xvfb/) and [here](https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui).