### PR TITLE
217-providers-suggest-order

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "esri-leaflet-geocoder",
-  "version": "2.2.13",
+  "version": "2.2.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3256,12 +3256,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3276,17 +3278,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3403,7 +3408,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3415,6 +3421,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3429,6 +3436,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3436,12 +3444,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3460,6 +3470,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3540,7 +3551,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3552,6 +3564,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3673,6 +3686,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/Classes/GeosearchCore.js
+++ b/src/Classes/GeosearchCore.js
@@ -75,7 +75,7 @@ export var GeosearchCore = Evented.extend({
         if (error) {
           // an error occurred for one of the providers' suggest requests
           this._control._clearProviderSuggestions(provider);
-          
+
           // perform additional cleanup when all requests are finished
           this._control._finalizeSuggestions(activeRequests, suggestionsLength);
 

--- a/src/Classes/GeosearchCore.js
+++ b/src/Classes/GeosearchCore.js
@@ -75,8 +75,12 @@ export var GeosearchCore = Evented.extend({
         activeRequests = activeRequests - 1;
 
         if (text.length < 2) {
-          this._suggestions.innerHTML = '';
           this._suggestions.style.display = 'none';
+
+          for (var i = 0; i < this.options.providers.length; i++) {
+            this.options.providers[i]._contentsElement.innerHTML = '';
+          }
+
           return;
         }
 
@@ -92,7 +96,7 @@ export var GeosearchCore = Evented.extend({
         if (provider._lastRender !== text && provider.nodes) {
           for (i = 0; i < provider.nodes.length; i++) {
             if (provider.nodes[i].parentElement) {
-              this._control._suggestions.removeChild(provider.nodes[i]);
+              provider._contentsElement.removeChild(provider.nodes[i])
             }
           }
 

--- a/src/Classes/GeosearchCore.js
+++ b/src/Classes/GeosearchCore.js
@@ -77,7 +77,7 @@ export var GeosearchCore = Evented.extend({
         if (text.length < 2) {
           this._suggestions.style.display = 'none';
 
-          for (var i = 0; i < this.options.providers.length; i++) {
+          for (i = 0; i < this.options.providers.length; i++) {
             this.options.providers[i]._contentsElement.innerHTML = '';
           }
 
@@ -96,7 +96,7 @@ export var GeosearchCore = Evented.extend({
         if (provider._lastRender !== text && provider.nodes) {
           for (i = 0; i < provider.nodes.length; i++) {
             if (provider.nodes[i].parentElement) {
-              provider._contentsElement.removeChild(provider.nodes[i])
+              provider._contentsElement.removeChild(provider.nodes[i]);
             }
           }
 

--- a/src/Controls/Geosearch.js
+++ b/src/Controls/Geosearch.js
@@ -68,7 +68,7 @@ export var Geosearch = Control.extend({
     for (var i = 0; i < suggestions.length; i++) {
       var suggestion = suggestions[i];
       if (!header && this._geosearchCore._providers.length > 1 && currentGroup !== suggestion.provider.options.label) {
-        header = DomUtil.create('span', 'geocoder-control-header', this._suggestions);
+        header = DomUtil.create('span', 'geocoder-control-header', suggestion.provider._contentsElement);
         header.textContent = suggestion.provider.options.label;
         header.innerText = suggestion.provider.options.label;
         currentGroup = suggestion.provider.options.label;
@@ -76,7 +76,7 @@ export var Geosearch = Control.extend({
       }
 
       if (!list) {
-        list = DomUtil.create('ul', 'geocoder-control-list', this._suggestions);
+        list = DomUtil.create('ul', 'geocoder-control-list', suggestion.provider._contentsElement);
       }
 
       if (suggestionTextArray.indexOf(suggestion.text) === -1) {
@@ -137,8 +137,11 @@ export var Geosearch = Control.extend({
   },
 
   clear: function () {
-    this._suggestions.innerHTML = '';
     this._suggestions.style.display = 'none';
+    
+    for (var i = 0; i < this.options.providers.length; i++) {
+      this.options.providers[i]._contentsElement.innerHTML = '';
+    }
 
     if (this.options.collapseAfterResult) {
       this._input.value = '';
@@ -216,7 +219,14 @@ export var Geosearch = Control.extend({
       this._input.placeholder = this.options.placeholder;
     }
 
+    // create the main suggested results container element
     this._suggestions = DomUtil.create('div', 'geocoder-control-suggestions leaflet-bar', this._wrapper);
+
+    // create a child contents container element for each provider inside of this._suggestions
+    // to maintain the configured order of providers for suggested results
+    for (var i = 0; i < this.options.providers.length; i++) {
+      this.options.providers[i]._contentsElement = DomUtil.create('span', null, this._suggestions);
+    }
 
     var credits = this._geosearchCore._getAttribution();
 
@@ -325,16 +335,24 @@ export var Geosearch = Control.extend({
 
       // require at least 2 characters for suggestions
       if (text.length < 2) {
-        this._suggestions.innerHTML = '';
         this._suggestions.style.display = 'none';
         DomUtil.removeClass(this._input, 'geocoder-control-loading');
+
+        for (var i = 0; i < this.options.providers.length; i++) {
+          this.options.providers[i]._contentsElement.innerHTML = '';
+        }
+
         return;
       }
 
       // if this is the escape key it will clear the input so clear suggestions
       if (key === 27) {
-        this._suggestions.innerHTML = '';
         this._suggestions.style.display = 'none';
+
+        for (var i = 0; i < this.options.providers.length; i++) {
+          this.options.providers[i]._contentsElement.innerHTML = '';
+        }
+
         return;
       }
 

--- a/src/Controls/Geosearch.js
+++ b/src/Controls/Geosearch.js
@@ -68,7 +68,7 @@ export var Geosearch = Control.extend({
     for (var i = 0; i < suggestions.length; i++) {
       var suggestion = suggestions[i];
       if (!header && this._geosearchCore._providers.length > 1 && currentGroup !== suggestion.provider.options.label) {
-        header = DomUtil.create('span', 'geocoder-control-header', suggestion.provider._contentsElement);
+        header = DomUtil.create('div', 'geocoder-control-header', suggestion.provider._contentsElement);
         header.textContent = suggestion.provider.options.label;
         header.innerText = suggestion.provider.options.label;
         currentGroup = suggestion.provider.options.label;
@@ -225,7 +225,7 @@ export var Geosearch = Control.extend({
     // create a child contents container element for each provider inside of this._suggestions
     // to maintain the configured order of providers for suggested results
     for (var i = 0; i < this.options.providers.length; i++) {
-      this.options.providers[i]._contentsElement = DomUtil.create('span', null, this._suggestions);
+      this.options.providers[i]._contentsElement = DomUtil.create('div', null, this._suggestions);
     }
 
     var credits = this._geosearchCore._getAttribution();

--- a/src/Controls/Geosearch.js
+++ b/src/Controls/Geosearch.js
@@ -150,11 +150,11 @@ export var Geosearch = Control.extend({
     }
   },
 
-  _clearProviderSuggestions: function(provider) {
+  _clearProviderSuggestions: function (provider) {
     provider._contentsElement.innerHTML = '';
   },
 
-  _finalizeSuggestions: function(activeRequests, suggestionsLength) {
+  _finalizeSuggestions: function (activeRequests, suggestionsLength) {
     // check if all requests are finished to remove the loading indicator
     if (!activeRequests) {
       DomUtil.removeClass(this._input, 'geocoder-control-loading');

--- a/src/Controls/Geosearch.js
+++ b/src/Controls/Geosearch.js
@@ -138,7 +138,7 @@ export var Geosearch = Control.extend({
 
   clear: function () {
     this._suggestions.style.display = 'none';
-    
+
     for (var i = 0; i < this.options.providers.length; i++) {
       this.options.providers[i]._contentsElement.innerHTML = '';
     }
@@ -349,8 +349,8 @@ export var Geosearch = Control.extend({
       if (key === 27) {
         this._suggestions.style.display = 'none';
 
-        for (var i = 0; i < this.options.providers.length; i++) {
-          this.options.providers[i]._contentsElement.innerHTML = '';
+        for (var j = 0; j < this.options.providers.length; j++) {
+          this.options.providers[j]._contentsElement.innerHTML = '';
         }
 
         return;

--- a/src/Controls/Geosearch.js
+++ b/src/Controls/Geosearch.js
@@ -60,7 +60,6 @@ export var Geosearch = Control.extend({
     // - 10 (extra padding)
     this._suggestions.style.maxHeight = (this._map.getSize().y - this._suggestions.offsetTop - this._wrapper.offsetTop - 10) + 'px';
 
-    var nodes = [];
     var list;
     var header;
     var suggestionTextArray = [];
@@ -72,7 +71,6 @@ export var Geosearch = Control.extend({
         header.textContent = suggestion.provider.options.label;
         header.innerText = suggestion.provider.options.label;
         currentGroup = suggestion.provider.options.label;
-        nodes.push(header);
       }
 
       if (!list) {
@@ -96,12 +94,6 @@ export var Geosearch = Control.extend({
       }
       suggestionTextArray.push(suggestion.text);
     }
-
-    DomUtil.removeClass(this._input, 'geocoder-control-loading');
-
-    nodes.push(list);
-
-    return nodes;
   },
 
   _boundsFromResults: function (results) {
@@ -137,11 +129,7 @@ export var Geosearch = Control.extend({
   },
 
   clear: function () {
-    this._suggestions.style.display = 'none';
-
-    for (var i = 0; i < this.options.providers.length; i++) {
-      this.options.providers[i]._contentsElement.innerHTML = '';
-    }
+    this._clearAllSuggestions();
 
     if (this.options.collapseAfterResult) {
       this._input.value = '';
@@ -154,12 +142,27 @@ export var Geosearch = Control.extend({
     }
   },
 
-  clearSuggestions: function () {
-    if (this._nodes) {
-      for (var k = 0; k < this._nodes.length; k++) {
-        if (this._nodes[k].parentElement) {
-          this._suggestions.removeChild(this._nodes[k]);
-        }
+  _clearAllSuggestions: function () {
+    this._suggestions.style.display = 'none';
+
+    for (var i = 0; i < this.options.providers.length; i++) {
+      this._clearProviderSuggestions(this.options.providers[i]);
+    }
+  },
+
+  _clearProviderSuggestions: function(provider) {
+    provider._contentsElement.innerHTML = '';
+  },
+
+  _finalizeSuggestions: function(activeRequests, suggestionsLength) {
+    // check if all requests are finished to remove the loading indicator
+    if (!activeRequests) {
+      DomUtil.removeClass(this._input, 'geocoder-control-loading');
+
+      // also check if there were 0 total suggest results to clear the parent suggestions element
+      // otherwise its display value may be "block" instead of "none"
+      if (!suggestionsLength) {
+        this._clearAllSuggestions();
       }
     }
   },
@@ -335,24 +338,14 @@ export var Geosearch = Control.extend({
 
       // require at least 2 characters for suggestions
       if (text.length < 2) {
-        this._suggestions.style.display = 'none';
+        this._clearAllSuggestions();
         DomUtil.removeClass(this._input, 'geocoder-control-loading');
-
-        for (var i = 0; i < this.options.providers.length; i++) {
-          this.options.providers[i]._contentsElement.innerHTML = '';
-        }
-
         return;
       }
 
       // if this is the escape key it will clear the input so clear suggestions
       if (key === 27) {
-        this._suggestions.style.display = 'none';
-
-        for (var j = 0; j < this.options.providers.length; j++) {
-          this.options.providers[j]._contentsElement.innerHTML = '';
-        }
-
+        this._clearAllSuggestions();
         return;
       }
 

--- a/src/Controls/Geosearch.js
+++ b/src/Controls/Geosearch.js
@@ -338,6 +338,7 @@ export var Geosearch = Control.extend({
 
       // require at least 2 characters for suggestions
       if (text.length < 2) {
+        this._lastValue = this._input.value;
         this._clearAllSuggestions();
         DomUtil.removeClass(this._input, 'geocoder-control-loading');
         return;


### PR DESCRIPTION
Resolves enhancement issue #217.

Changes include:
- Now provider suggestion results are housed within a new DOM element child container for each provider, in order to maintain the configured order of providers for suggested results.
- Clearing the parent `this._suggestions` is handled a little bit differently.  Instead of its `innerHTML` being set to `''`, each of the providers' child container is cleared out; again, this is to maintain the original configured order.

Some questions which might create more work for another PR(s):
1. I can't tell how the `clearSuggestions` method is being actively used. Is this a holdover from previous functionality? https://github.com/Esri/esri-leaflet-geocoder/blob/87c9b7ed5335cfba88631b757c41a1fbb3519493/src/Controls/Geosearch.js#L157  It is being called from here but doesn't quite make sense to me. https://github.com/Esri/esri-leaflet-geocoder/blob/87c9b7ed5335cfba88631b757c41a1fbb3519493/src/Classes/GeosearchCore.js#L107
2. **Unrelated to this PR**, there are cases when suggestions should be generated but are not.  This is due to `this._lastValue` being perhaps a little too strict and its value could maybe be set in more places. Consider a user experience when (1) getting suggestions then (2) blurring from the input element then (3) returning to the input element and attempting to get fresh suggestions for the exact same search text.   https://github.com/Esri/esri-leaflet-geocoder/blob/87c9b7ed5335cfba88631b757c41a1fbb3519493/src/Controls/Geosearch.js#L361-L362