### PR TITLE
225-providers-check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Upcoming changes][Unreleased]
 
+### Fixed
+
+* Ensure control initialization will be successful when there are no optional `providers` passed in. [#225](https://github.com/Esri/esri-leaflet-geocoder/issues/225)
+
 ## [2.3.0] - 2019-10-10
 
 ### Changed

--- a/spec/Controls/GeosearchSpec.js
+++ b/spec/Controls/GeosearchSpec.js
@@ -37,10 +37,13 @@ describe('L.esri.Geosearch', function () {
   var mapbounds = L.latLngBounds(southWest, northEast);
 
   it('shouldnt overwrite custom options set in the constructor', function () {
+    var customProviders = [
+      L.esri.Geocoding.arcgisOnlineProvider(),
+      L.esri.Geocoding.arcgisOnlineProvider()
+    ];
+
     var geosearch = L.esri.Geocoding.geosearch({
-      providers: [
-        L.esri.Geocoding.arcgisOnlineProvider()
-      ],
+      providers: customProviders,
       useMapBounds: false,
       zoomToResult: false,
       collapseAfterResult: false,
@@ -50,6 +53,9 @@ describe('L.esri.Geosearch', function () {
       title: 'something not so clever',
       searchBounds: mapbounds
     });
+
+    expect(geosearch.options.providers.length).to.equal(customProviders.length);
+    expect(geosearch._geosearchCore.options.providers.length).to.equal(customProviders.length);
 
     expect(geosearch.options.useMapBounds).to.equal(false);
     expect(geosearch.options.zoomToResult).to.equal(false);
@@ -75,6 +81,22 @@ describe('L.esri.Geosearch', function () {
 
     expect(geosearch._geosearchCore.options.useMapBounds).to.equal(false);
     expect(geosearch._geosearchCore.options.searchBounds).to.equal(mapbounds);
+  });
+
+  it('and even if no provider is passed there should at least be 1 by default', function () {
+    var geosearch = L.esri.Geocoding.geosearch({
+      useMapBounds: false,
+      zoomToResult: false,
+      collapseAfterResult: false,
+      expanded: true,
+      allowMultipleResults: false,
+      placeholder: 'something clever',
+      title: 'something not so clever',
+      searchBounds: mapbounds
+    });
+
+    expect(geosearch.options.providers.length).to.equal(1);
+    expect(geosearch._geosearchCore.options.providers.length).to.equal(1);
   });
 
   it('should update map attribution when the World Geocoding Service is used', function () {

--- a/src/Controls/Geosearch.js
+++ b/src/Controls/Geosearch.js
@@ -44,7 +44,7 @@ export var Geosearch = Control.extend({
 
     this._geosearchCore._pendingSuggestions = [];
 
-    Control.prototype.initialize.call(options);
+    Control.prototype.initialize.call(this, options);
   },
 
   _renderSuggestions: function (suggestions) {


### PR DESCRIPTION
Resolves #225.  A legitimate case was missed during human testing of enhancement #217. 

- Now the geocoder control shouldn't fail when there are no optional `providers` passed in.
- Added some related tests but these could likely be improved upon.

I recommend publishing another release after this makes it in (v2.3.1?).  Should we deprecate v2.3.0 after all is said and done?