### PR TITLE
Add Option for "Strict" Feature Layer Search

### DIFF
--- a/debug/sample.html
+++ b/debug/sample.html
@@ -53,9 +53,8 @@
             label: 'Cities',
             formatSuggestion: function (feature) {
               return feature.properties.areaname + ', ' + feature.properties.st;
-            },
-            strictSearch: false // set to true to force exact match
-          })          
+            }                       
+          })                    
         ]
       }).addTo(map);
 

--- a/debug/sample.html
+++ b/debug/sample.html
@@ -46,7 +46,16 @@
             url: 'http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer',
             layers: [2, 3],
             searchFields: ['NAME', 'STATE_NAME']
-          })
+          }),
+          L.esri.Geocoding.featureLayerProvider({
+            url: 'https://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer/0',
+            searchFields: ['areaname'],
+            label: 'Cities',
+            formatSuggestion: function (feature) {
+              return feature.properties.areaname + ', ' + feature.properties.st;
+            },
+            strictSearch: false // set to true to force exact match
+          })          
         ]
       }).addTo(map);
 

--- a/src/Providers/FeatureLayer.js
+++ b/src/Providers/FeatureLayer.js
@@ -104,11 +104,11 @@ export var FeatureLayerProvider = FeatureLayerService.extend({
       var field = 'upper("' + this.options.searchFields[i] + '")';
       
       if (!this.options.strictSearch) {
-       queryString.push(field + " LIKE upper('%" + text + "%')");
+        queryString.push(field + " LIKE upper('%" + text + "%')");
       } else {
-         queryString.push(field + " LIKE upper('" + text + "')");
-        }
+        queryString.push(field + " LIKE upper('" + text + "')");
       }
+    }
     
     if (this.options.where) {
       return this.options.where + ' AND (' + queryString.join(' OR ') + ')';

--- a/src/Providers/FeatureLayer.js
+++ b/src/Providers/FeatureLayer.js
@@ -104,12 +104,12 @@ export var FeatureLayerProvider = FeatureLayerService.extend({
       var field = 'upper("' + this.options.searchFields[i] + '")';
       
       if (!this.options.strictSearch) {
-        queryString.push(field + " LIKE upper('%" + text + "%')");
+       queryString.push(field + " LIKE upper('%" + text + "%')");
       } else {
-        queryString.push(field + " LIKE upper('" + text + "')");
-      }     
-    }
-
+         queryString.push(field + " LIKE upper('" + text + "')");
+        }
+      }
+    
     if (this.options.where) {
       return this.options.where + ' AND (' + queryString.join(' OR ') + ')';
     } else {

--- a/src/Providers/FeatureLayer.js
+++ b/src/Providers/FeatureLayer.js
@@ -6,7 +6,7 @@ export var FeatureLayerProvider = FeatureLayerService.extend({
     label: 'Feature Layer',
     maxResults: 5,
     bufferRadius: 1000,
-    strictSearch: false,
+    searchMode: 'contain',
     formatSuggestion: function (feature) {
       return feature.properties[this.options.searchFields[0]];
     }
@@ -103,10 +103,14 @@ export var FeatureLayerProvider = FeatureLayerService.extend({
     for (var i = this.options.searchFields.length - 1; i >= 0; i--) {
       var field = 'upper("' + this.options.searchFields[i] + '")';
       
-      if (!this.options.strictSearch) {
+      if (this.options.searchMode === 'contain') {
         queryString.push(field + " LIKE upper('%" + text + "%')");
-      } else {
+      } else if (this.options.searchMode === 'startWith') {
+        queryString.push(field + " LIKE upper('" + text + "%')");
+      } else if (this.options.searchMode === 'strict') {
         queryString.push(field + " LIKE upper('" + text + "')");
+      } else {
+        throw new Error('L.esri.Geocoding.featureLayerProvider: Invalid parameter for "searchMode". Use one of "contain", "startWith", or "strict"');
       }
     }
     

--- a/src/Providers/FeatureLayer.js
+++ b/src/Providers/FeatureLayer.js
@@ -6,6 +6,7 @@ export var FeatureLayerProvider = FeatureLayerService.extend({
     label: 'Feature Layer',
     maxResults: 5,
     bufferRadius: 1000,
+    strictSearch: false,
     formatSuggestion: function (feature) {
       return feature.properties[this.options.searchFields[0]];
     }
@@ -101,8 +102,12 @@ export var FeatureLayerProvider = FeatureLayerService.extend({
 
     for (var i = this.options.searchFields.length - 1; i >= 0; i--) {
       var field = 'upper("' + this.options.searchFields[i] + '")';
-
-      queryString.push(field + " LIKE upper('%" + text + "%')");
+      
+      if (!this.options.strictSearch) {
+        queryString.push(field + " LIKE upper('%" + text + "%')");
+      } else {
+        queryString.push(field + " LIKE upper('" + text + "')");
+      }     
     }
 
     if (this.options.where) {


### PR DESCRIPTION
Add an option to Feature Layer search constructor to force a "strict" search.  Related to #244.

I did an initial test in debug with the option "**strictSearch**" set to `true` or `false`.   For the city "Harrisburg," I would test as "Har.." and "rrisb" to ensure it is working.

There may be a more performant way to add the request in #244.  