### PR TITLE
250-multi-magic-keys-bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Upcoming changes][Unreleased]
 
+### Fixed
+
+* Suggestions for the provider `L.esri.Geocoding.mapServiceProvider` with more than 1 magic key are now geocoded correctly when selected and will show all available results on the map. [#250](https://github.com/Esri/esri-leaflet-geocoder/issues/250)
+
 ## [2.3.3] - 2020-05-29
 
 ### Added

--- a/debug/sample.html
+++ b/debug/sample.html
@@ -54,8 +54,8 @@
             label: 'Cities',
             formatSuggestion: function (feature) {
               return feature.properties.areaname + ', ' + feature.properties.st;
-            }                       
-          })                    
+            }
+          })
         ]
       }).addTo(map);
 

--- a/spec/Providers/FeatureLayerSpec.js
+++ b/spec/Providers/FeatureLayerSpec.js
@@ -88,6 +88,54 @@ describe('L.esri.Geosearch.FeatureLayer', function () {
     ]
   });
 
+  var resultMultiQueryResponse = JSON.stringify({
+    'objectIdFieldName': 'FID',
+    'fields': [{
+      'name': 'Name',
+      'type': 'esriFieldTypeString',
+      'alias': 'Name',
+      'sqlType': 'sqlTypeNVarchar',
+      'length': 256,
+      'domain': null,
+      'defaultValue': null
+    }, {
+      'name': 'FID',
+      'type': 'esriFieldTypeOID',
+      'alias': 'FID',
+      'sqlType': 'sqlTypeInteger',
+      'domain': null,
+      'defaultValue': null
+    }],
+    'features': [
+      {
+        'attributes': {
+          'FID': 1,
+          'Name': 'Place 1'
+        },
+        'geometry': {
+          'x': -122.81,
+          'y': 45.48,
+          'spatialReference': {
+            'wkid': 4326
+          }
+        }
+      },
+      {
+        'attributes': {
+          'FID': 2,
+          'Name': 'Place 2'
+        },
+        'geometry': {
+          'x': -122.81,
+          'y': 45.48,
+          'spatialReference': {
+            'wkid': 4326
+          }
+        }
+      }
+    ]
+  });
+
   it('should query based on text', function (done) {
     var request = provider.suggestions('Pla', null, function (error, results) {
       expect(results.length).to.equal(2);
@@ -129,6 +177,25 @@ describe('L.esri.Geosearch.FeatureLayer', function () {
     expect(request.url).to.contain('objectIds=1');
 
     request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, resultQueryResponse);
+  });
+
+  it('should query with more than 1 magic keys', function (done) {
+    var request = provider.results('Place', '1,2', null, function (error, results) {
+      expect(results.length).to.equal(2);
+
+      expect(results[0].latlng.lat).to.equal(45.48);
+      expect(results[0].latlng.lng).to.equal(-122.81);
+      expect(results[0].text).to.equal('Place 2');
+
+      expect(results[1].latlng.lat).to.equal(45.48);
+      expect(results[1].latlng.lng).to.equal(-122.81);
+      expect(results[1].text).to.equal('Place 1');
+      done();
+    });
+
+    expect(request.url).to.contain('objectIds=1%2C2'); // 'objectIds=1,2'
+
+    request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, resultMultiQueryResponse);
   });
 
   it('should query for partial text', function (done) {

--- a/spec/Providers/MapServiceSpec.js
+++ b/spec/Providers/MapServiceSpec.js
@@ -139,6 +139,29 @@ describe('L.esri.Geosearch.MapService', function () {
     request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, sampleFindResponse);
   });
 
+  it('should geocode when there are more than 1 magic keys', function (done) {
+    var request = provider.results('Place', null, null, function (error, results) {
+      expect(results.length).to.equal(2);
+
+      expect(results[0].latlng.lat).to.equal(45.48);
+      expect(results[0].latlng.lng).to.equal(-122.81);
+      expect(results[0].text).to.contain('Place 1');
+
+      expect(results[1].latlng.lat).to.equal(45.48);
+      expect(results[1].latlng.lng).to.equal(-122.81);
+      expect(results[1].text).to.contain('Place 2');
+
+      done();
+    });
+
+    expect(request.url).to.contain('http://example.com/arcgis/arcgis/rest/services/MockService/find');
+    expect(request.url).to.contain('searchText=Place');
+    expect(request.url).to.contain('searchFields=Name');
+    expect(request.url).to.contain('layers=0');
+
+    request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, sampleFindResponse);
+  });
+
   it('pass a token through', function (done) {
     provider.options.token = 'idunno';
     var request = provider.results('Pla', null, null, function (error, results) {

--- a/spec/Providers/MapServiceSpec.js
+++ b/spec/Providers/MapServiceSpec.js
@@ -140,7 +140,7 @@ describe('L.esri.Geosearch.MapService', function () {
   });
 
   it('should geocode when there are more than 1 magic keys', function (done) {
-    var request = provider.results('Place', null, null, function (error, results) {
+    var request = provider.results('Place', '1:0,2:0', null, function (error, results) {
       expect(results.length).to.equal(2);
 
       expect(results[0].latlng.lat).to.equal(45.48);

--- a/src/Providers/FeatureLayer.js
+++ b/src/Providers/FeatureLayer.js
@@ -58,9 +58,11 @@ export var FeatureLayerProvider = FeatureLayerService.extend({
     var query = this._resultsQuery;
 
     if (key) {
+      // if there are 1 or more keys available, use query.featureIds()
       delete query.params.where;
       query.featureIds([key]);
     } else {
+      // if there are no keys available, use query.where()
       query.where(this._buildQuery(text));
     }
 

--- a/src/Providers/MapService.js
+++ b/src/Providers/MapService.js
@@ -50,11 +50,13 @@ export var MapServiceProvider = MapService.extend({
     var results = [];
     var request;
 
-    if (key) {
+    if (key && !key.includes(',')) {
+      // if there is only 1 key available, use query()
       var featureId = key.split(':')[0];
       var layer = key.split(':')[1];
       request = this.query().layer(layer).featureIds(featureId);
     } else {
+      // if there are no keys or more than 1 keys available, use find()
       request = this.find().text(text).fields(this.options.searchFields).layers(this.options.layers);
     }
 


### PR DESCRIPTION
Resolves #250.

- Fixed incorrect query vs. find REST request for the MapService provider when there are more than 1 magic keys available. (See issue comments in #250.)
- Added source code comments for both MapService and FeatureLayer providers regarding usage of keys.
- Added tests for MapService and FeatureLayer providers when there are more than 1 keys available.
- Misc. formatting for debug sample.html.