### PR TITLE
273-remove-suggest-pad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Upcoming changes][Unreleased]
 
+### Fixed
+
+* Results for the `suggest` and `findAddressCandidates` operations should now be more consistent with each other when using a `searchBounds` option. We removed an automatically applied bounds padding that was only present in the `suggest`'s `within` method. [#274](https://github.com/Esri/esri-leaflet-geocoder/pull/274)
+
 ## [3.0.0] - 2021-01-25
 
 ### Added
@@ -37,7 +41,6 @@ var searchControl = L.esri.Geocoding.geosearch({
 }).addTo(map);
 ```
 Other providers may be used with or without an api key.
-
 
 ## [2.3.4] - 2020-12-29
 

--- a/spec/Controls/GeosearchSpec.js
+++ b/spec/Controls/GeosearchSpec.js
@@ -126,7 +126,7 @@ describe('L.esri.Geosearch', function () {
     this.requests[0].respond(200, { 'Content-Type': 'application/json' },
                                  JSON.stringify({'suggestions': []}));
 
-    expect(geosearch._geosearchCore._pendingSuggestions[0].url).to.equal('https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/suggest?text=Mayoworth%2C%20WY&location=-97.64%2C30.32&distance=50000&searchExtent=%7B%22xmin%22%3A-101.78%2C%22ymin%22%3A28.28%2C%22xmax%22%3A-93.5%2C%22ymax%22%3A32.36%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&maxSuggestions=6&f=json');
+    expect(geosearch._geosearchCore._pendingSuggestions[0].url).to.equal('https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/suggest?text=Mayoworth%2C%20WY&location=-97.63999999999999%2C30.32&distance=50000&searchExtent=%7B%22xmin%22%3A-99.71%2C%22ymin%22%3A29.3%2C%22xmax%22%3A-95.57%2C%22ymax%22%3A31.34%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&maxSuggestions=6&f=json');
     done();
   });
 

--- a/src/Tasks/Suggest.js
+++ b/src/Tasks/Suggest.js
@@ -28,7 +28,6 @@ export var Suggest = Task.extend({
 
   within: function (bounds) {
     bounds = latLngBounds(bounds);
-    bounds = bounds.pad(0.5);
     var center = bounds.getCenter();
     var ne = bounds.getNorthWest();
     this.params.location = center.lng + ',' + center.lat;


### PR DESCRIPTION
Alleviates different "/suggest" vs. "/findAddressCandidates" behavior when a `searchBounds` option is used, by removing the automatically applied `bounds.pad(0.5)` in the suggest `within` method.

Related to #273.

Try to search for "park bench cafe" as described in #273 in the JSBin example, and then try again in a local checkout of this PR with the code sample provided below.

<details>
  <summary markdown="span">local demo sample</summary>

```html
<!DOCTYPE html>
<html>

<head>
  <meta charset="utf-8" />
  <title>Geocoding control</title>
  <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />

  <link rel="stylesheet" href="../node_modules/leaflet/dist/leaflet.css" />
  <script src="../node_modules/leaflet/dist/leaflet-src.js"></script>

  <script src="../node_modules/esri-leaflet/dist/esri-leaflet-debug.js"></script>

  <link rel="stylesheet" href="../dist/esri-leaflet-geocoder.css" />
  <script src="../dist/esri-leaflet-geocoder-debug.js"></script>
  <style>
    body {
      margin: 0;
      padding: 0;
    }

    #map {
      position: absolute;
      top: 0;
      bottom: 0;
      right: 0;
      left: 0;
    }
  </style>
</head>

<body>

  <div id="map"></div>

  <script>
    var map = L.map('map').setView([40.91, -96.63], 4);

    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
      attribution: '&copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors'
    }).addTo(map);

    const southWest = L.latLng(33.685131100831214, -117.98251451552146);
    const northEast = L.latLng(33.73448856010863, -117.91114531893689);
    const searchBounds = L.latLngBounds(southWest, northEast);

    var rectangle = L.rectangle(searchBounds).addTo(map);

    var searchControl = L.esri.Geocoding.geosearch({
      position: 'topright',
      placeholder: 'Enter an address or place e.g. 1 York St',
      useMapBounds: false,
      searchBounds: searchBounds,
      providers: [L.esri.Geocoding.arcgisOnlineProvider({
        apikey: 'ABC XYZ YOUR KEY',
      })]
    }).addTo(map);

    var results = L.layerGroup().addTo(map);

    searchControl.on('results', function (data) {
      results.clearLayers();
      for (var i = data.results.length - 1; i >= 0; i--) {
        results.addLayer(L.marker(data.results[i].latlng));
      }
    });
  </script>

</body>

</html>
```
</details>
