### PR TITLE
for reverseGeocode, pass through apikey and token

### DIFF
--- a/spec/Tasks/ReverseGeocodeSpec.js
+++ b/spec/Tasks/ReverseGeocodeSpec.js
@@ -105,5 +105,25 @@ describe('L.esri.ReverseGeocode', function () {
 
     request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, sampleFrenchResponse);
   });
+
+  it('should pass through a token', function (done) {
+    var request = L.esri.Geocoding.reverseGeocode({ token: 'testToken' }).latlng([48.8583, 2.2945]).run(function (error, result, response) {
+      done();
+    });
+
+    expect(request.url).to.contain('token=testToken');
+
+    request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, sampleResponse);
+  });
+
+  it('should pass through an apikey', function (done) {
+    var request = L.esri.Geocoding.reverseGeocode({ apikey: 'testApiKey' }).latlng([48.8583, 2.2945]).run(function (error, result, response) {
+      done();
+    });
+
+    expect(request.url).to.contain('token=testApiKey');
+
+    request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, sampleResponse);
+  });
 });
 /* eslint-disable handle-callback-err */

--- a/src/Tasks/ReverseGeocode.js
+++ b/src/Tasks/ReverseGeocode.js
@@ -13,7 +13,8 @@ export var ReverseGeocode = Task.extend({
   setters: {
     distance: 'distance',
     language: 'langCode',
-    intersection: 'returnIntersection'
+    intersection: 'returnIntersection',
+    apikey: 'apikey'
   },
 
   initialize: function (options) {
@@ -29,6 +30,12 @@ export var ReverseGeocode = Task.extend({
   },
 
   run: function (callback, context) {
+    if (this.options.token) {
+      this.params.token = this.options.token;
+    }
+    if (this.options.apikey) {
+      this.params.token = this.options.apikey;
+    }
     return this.request(function (error, response) {
       var result;
 


### PR DESCRIPTION
properly pass through `token` and `apikey` for `.reverseGeocode()`.

similar to #278. That PR was fixing `geocode()` where this PR is for `reverseGeocode()`

fixes #294 and #282