### PR TITLE
Increase z-index of geocoder-control element

### DIFF
--- a/src/esri-leaflet-geocoder.css
+++ b/src/esri-leaflet-geocoder.css
@@ -35,6 +35,10 @@
   transition: width .175s ease-in;
 }
 
+.geocoder-control.leaflet-control {
+  z-index: 801;
+}
+
 .geocoder-control-expanded,
 .leaflet-touch .geocoder-control-expanded {
   width: 275px;


### PR DESCRIPTION
Based on [this issue](https://github.com/Esri/esri-leaflet-geocoder/issues/230) where Geocoder suggestions appear under other Leaflet controls, this PR resolves that by increasing the z-index of the control itself from `800` as defined by Leaflet, to `801`.

Working example [here](https://codepen.io/McGaber/pen/GRbVyXx)
NOTE: You will need to supply your own Esri API key in the Codepen.