### PR TITLE
fix: Include CSS source files in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "files": [
     "src/**/*.js",
+    "src/**/*.css",
     "dist/**",
     "index.d.ts"
   ],


### PR DESCRIPTION
Fixes #322 

![image](https://github.com/user-attachments/assets/fe589504-93b7-454c-a1c8-3d6a9187cd5c)
